### PR TITLE
feat(ripple): add `unresolve()` to reverse an adjudication decision

### DIFF
--- a/atlas_core/ripple/resolver.py
+++ b/atlas_core/ripple/resolver.py
@@ -73,6 +73,23 @@ class ResolveOutcome:
     notes: list[str] = field(default_factory=list)
 
 
+@dataclass
+class UnresolveOutcome:
+    """Returned by `unresolve()` — the reversal of an applied resolution.
+
+    `reverted_kref` is the revision the resolution created (no longer
+    current). `restored_kref` is the revision it had superseded, now
+    current again. Nothing is deleted; the reversal is itself a logged,
+    reversible tag move.
+    """
+
+    reverted_kref: str
+    restored_kref: str
+    root_kref: str
+    tag: str
+    ledger_event_id: str | None = None
+
+
 # ─── Frontmatter parser ─────────────────────────────────────────────────────
 
 
@@ -291,5 +308,141 @@ async def resolve_adjudication(
         "new_revision=%s ledger_event=%s",
         proposal_id, decision, outcome.applied,
         outcome.new_revision_kref, outcome.ledger_event_id,
+    )
+    return outcome
+
+
+# ─── Unresolve ──────────────────────────────────────────────────────────────
+
+
+async def unresolve(
+    revision_kref: str,
+    *,
+    driver: AsyncDriver,
+    ledger: HashChainedLedger,
+    actor: str = "rich",
+    tag: str = "current",
+) -> UnresolveOutcome:
+    """Reverse an applied resolution by re-pointing the active tag back to the
+    revision that the resolution superseded.
+
+    Append-only and audited:
+      - The revision the resolution created stays in the graph, along with its
+        SUPERSEDES edge — nothing is destroyed, so the reversal is itself
+        reversible (re-resolve to go forward again).
+      - An INVALIDATE ledger event records what was reverted and what was
+        restored, keeping the hash-chained audit trail complete.
+
+    Args:
+        revision_kref: kref of the revision created by the resolution — i.e.
+            ResolveOutcome.new_revision_kref. Must be the one the tag currently
+            points to.
+        driver: Live Neo4j driver
+        ledger: Hash-chained ledger — gets the reversal audit event
+        actor: Audit attribution; defaults to 'rich'
+        tag: Which tag to move back; defaults to 'current'
+
+    Returns:
+        UnresolveOutcome with reverted_kref / restored_kref / ledger_event_id
+
+    Raises:
+        ValueError: revision not found, no superseded revision to revert to,
+            or the revision is not the active one at the tag.
+    """
+    gather_cypher = """
+    MATCH (rev:AtlasRevision {kref: $rev_kref})
+    OPTIONAL MATCH (rev)-[:SUPERSEDES]->(prior:AtlasRevision)
+    OPTIONAL MATCH (:AtlasTag {name: $tag, root_kref: rev.root_kref})
+                   -[:POINTS_TO]->(cur:AtlasRevision)
+    RETURN rev.root_kref AS root_kref,
+           prior.kref AS prior_kref,
+           cur.kref AS current_kref
+    """
+    async with driver.session() as session:
+        result = await session.run(
+            gather_cypher, rev_kref=revision_kref, tag=tag
+        )
+        record = await result.single()
+
+    if record is None:
+        raise ValueError(f"revision not found: {revision_kref!r}")
+
+    root_kref = record["root_kref"]
+    prior_kref = record["prior_kref"]
+    current_kref = record["current_kref"]
+
+    # You can only unresolve the active revision — check that first so a
+    # stale kref gets the precise error rather than a misleading one.
+    if current_kref != revision_kref:
+        raise ValueError(
+            f"revision {revision_kref!r} is not the active revision at "
+            f"tag {tag!r} (current is {current_kref!r}); refusing to "
+            f"re-point the tag"
+        )
+    if prior_kref is None:
+        raise ValueError(
+            f"revision {revision_kref!r} has no superseded revision to "
+            f"revert to (it was the first revision)"
+        )
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    repoint_cypher = """
+    MATCH (tag:AtlasTag {name: $tag, root_kref: $root_kref})
+    OPTIONAL MATCH (tag)-[old:POINTS_TO]->(:AtlasRevision)
+    DELETE old
+    WITH tag
+    MATCH (prior:AtlasRevision {kref: $prior_kref})
+    CREATE (tag)-[:POINTS_TO {moved_at: $timestamp, reverted_from: $rev_kref}]->(prior)
+    RETURN prior.kref AS restored
+    """
+    async with driver.session() as session:
+        result = await session.run(
+            repoint_cypher,
+            tag=tag,
+            root_kref=root_kref,
+            prior_kref=prior_kref,
+            rev_kref=revision_kref,
+            timestamp=timestamp,
+        )
+        repoint = await result.single()
+
+    if repoint is None:
+        raise RuntimeError(
+            f"unresolve: failed to re-point tag {tag!r} for {root_kref!r}"
+        )
+
+    outcome = UnresolveOutcome(
+        reverted_kref=revision_kref,
+        restored_kref=prior_kref,
+        root_kref=root_kref,
+        tag=tag,
+    )
+
+    from atlas_core.trust.ledger import EventType
+
+    ledger_event = ledger.append_event(
+        event_type=EventType.INVALIDATE,
+        actor_id=actor,
+        object_id=revision_kref,
+        object_type="ripple_unresolve",
+        root_id=root_kref,
+        target_object_id=prior_kref,
+        reason=(
+            f"unresolve: reverted {revision_kref}, restored {prior_kref} "
+            f"as {tag}"
+        ),
+        payload={
+            "reverted_kref": revision_kref,
+            "restored_kref": prior_kref,
+            "tag": tag,
+            "actor": actor,
+            "reverted_at": timestamp,
+        },
+    )
+    outcome.ledger_event_id = ledger_event.event_id
+
+    log.info(
+        "Unresolve: reverted=%s restored=%s tag=%s ledger_event=%s",
+        revision_kref, prior_kref, tag, outcome.ledger_event_id,
     )
     return outcome

--- a/tests/integration/test_adjudication_resolver.py
+++ b/tests/integration/test_adjudication_resolver.py
@@ -273,6 +273,142 @@ class TestResolveRoundtrip:
             )
 
 
+# ─── Unresolve (reverse a resolution) ───────────────────────────────────────
+
+
+class TestUnresolve:
+    """`unresolve` reverses an applied resolution by re-pointing the active
+    tag back to the superseded revision. Append-only: the revision the
+    resolution created stays in the graph; the reversal is itself audited.
+    Issue #15.
+    """
+
+    async def _current_revision_kref(self, driver, root_kref: str) -> str | None:
+        async with driver.session() as session:
+            result = await session.run(
+                "MATCH (:AtlasTag {name:'current', root_kref:$root})"
+                "-[:POINTS_TO]->(r:AtlasRevision) RETURN r.kref AS kref",
+                root=root_kref,
+            )
+            row = await result.single()
+            return row["kref"] if row else None
+
+    async def test_unresolve_restores_prior_revision(
+        self, driver, ledger, tmp_dir, ns,
+    ):
+        from atlas_core.revision.agm import revise
+        from atlas_core.revision.uri import Kref
+        from atlas_core.ripple.resolver import (
+            resolve_adjudication,
+            unresolve,
+        )
+
+        target_kref = f"kref://{ns}/Beliefs/undo_me.belief"
+        root_kref = Kref.parse(target_kref).root_kref().to_string()
+
+        # Seed an original revision (rev1), tag current -> rev1.
+        seed = await revise(
+            driver=driver,
+            target_kref=Kref.parse(target_kref),
+            new_content={"confidence": 0.85},
+            revision_reason="seed original belief",
+            actor="rich",
+        )
+        rev1 = seed.new_revision_kref.to_string()
+
+        # Accept-resolve -> creates rev2 SUPERSEDES rev1, tag current -> rev2.
+        adj_dir = tmp_dir / "adjudication"
+        _write_adjudication_file(
+            directory=adj_dir,
+            proposal_id="adj_undo",
+            target_kref=target_kref,
+            current=0.85, proposed=0.40,
+        )
+        resolved = await resolve_adjudication(
+            "adj_undo", "accept",
+            driver=driver, ledger=ledger, directory=adj_dir,
+        )
+        rev2 = resolved.new_revision_kref
+        assert resolved.superseded_kref == rev1
+        assert await self._current_revision_kref(driver, root_kref) == rev2
+
+        # Unresolve rev2 -> tag current back to rev1.
+        un = await unresolve(
+            rev2, driver=driver, ledger=ledger, actor="rich",
+        )
+
+        assert un.reverted_kref == rev2
+        assert un.restored_kref == rev1
+        assert un.ledger_event_id
+
+        # The active belief is rev1 again.
+        assert await self._current_revision_kref(driver, root_kref) == rev1
+
+        # Nothing destroyed: rev2 still exists and still SUPERSEDES rev1.
+        async with driver.session() as session:
+            result = await session.run(
+                "MATCH (a:AtlasRevision {kref:$rev2})-[:SUPERSEDES]->"
+                "(b:AtlasRevision {kref:$rev1}) RETURN a.kref AS k",
+                rev2=rev2, rev1=rev1,
+            )
+            assert await result.single() is not None
+
+        # Reversal is audited; ledger chain stays verifiable.
+        chain = ledger.verify_chain()
+        assert chain.intact is True
+
+    async def test_unresolve_first_revision_raises(
+        self, driver, ledger, tmp_dir, ns,
+    ):
+        """A revision with no SUPERSEDES target has nothing to revert to."""
+        from atlas_core.revision.agm import revise
+        from atlas_core.revision.uri import Kref
+        from atlas_core.ripple.resolver import unresolve
+
+        target_kref = f"kref://{ns}/Beliefs/only_one.belief"
+        seed = await revise(
+            driver=driver,
+            target_kref=Kref.parse(target_kref),
+            new_content={"confidence": 0.70},
+            revision_reason="first and only revision",
+            actor="rich",
+        )
+        with pytest.raises(ValueError, match="no superseded revision"):
+            await unresolve(
+                seed.new_revision_kref.to_string(),
+                driver=driver, ledger=ledger,
+            )
+
+    async def test_unresolve_non_current_revision_raises(
+        self, driver, ledger, tmp_dir, ns,
+    ):
+        """Refuse to unresolve a revision that isn't the active one — that
+        would silently corrupt the tag pointer."""
+        from atlas_core.revision.agm import revise
+        from atlas_core.revision.uri import Kref
+        from atlas_core.ripple.resolver import unresolve
+
+        target_kref = f"kref://{ns}/Beliefs/stale.belief"
+        seed = await revise(
+            driver=driver,
+            target_kref=Kref.parse(target_kref),
+            new_content={"confidence": 0.60},
+            revision_reason="rev1",
+            actor="rich",
+        )
+        rev1 = seed.new_revision_kref.to_string()
+        await revise(
+            driver=driver,
+            target_kref=Kref.parse(target_kref),
+            new_content={"confidence": 0.30},
+            revision_reason="rev2 (now current)",
+            actor="rich",
+        )
+        # rev1 is no longer current; reversing it is not allowed.
+        with pytest.raises(ValueError, match="not the active revision"):
+            await unresolve(rev1, driver=driver, ledger=ledger)
+
+
 # ─── Frontmatter parser ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #15. Raised by `pavelpilyak` on the [Show HN thread](https://news.ycombinator.com/item?id=48509753): *is there an undo if I mess one up?*

## What

Resolving a contradiction was already append-only and recoverable, but there was no one-button undo. `unresolve(revision_kref)` re-points the active tag back to the revision the resolution superseded.

## How it stays honest

- **Append-only:** the superseding revision and its `SUPERSEDES` edge stay in the graph. Nothing is destroyed, so the reversal is itself reversible (re-resolve to go forward again).
- **Audited:** an `INVALIDATE` ledger event records the reverted + restored krefs, keeping the hash-chained trail complete and `verify_chain()`-clean.
- **Guarded:** refuses a revision that isn't the active one at the tag (re-pointing it would silently corrupt state), and a first revision (nothing to revert to).

## Tests (TDD, written first)

3 integration tests in `test_adjudication_resolver.py::TestUnresolve`:
- full `resolve` → `unresolve` round-trip: tag restored to the prior revision, superseding revision + edge preserved, ledger chain intact
- first-revision guard raises
- non-active-revision guard raises

Local run: lint clean, **521 passing** (518 + 3 new) against Neo4j 5.26.

## Not in this PR

Surfacing `unresolve` through the CLI / MCP / HTTP layers (the markdown-queue UX) is the natural follow-up — this PR lands the audited core operator.