### PR TITLE
fix: close community reports #17, #18, #20, and #21

### DIFF
--- a/.github/ISSUE_TEMPLATE/tester-smoke.md
+++ b/.github/ISSUE_TEMPLATE/tester-smoke.md
@@ -1,6 +1,6 @@
 ---
 name: Tester report — smoke test (`pytest tests/`)
-about: The 318-test suite went red on a clean checkout
+about: The full test suite went red on a clean checkout
 labels: tester-finding, smoke-test
 ---
 
@@ -14,7 +14,7 @@ labels: tester-finding, smoke-test
 
 ## Expected vs actual
 
-- Expected: 318 passed
+- Expected: 500+ passed with no failures or teardown errors
 - Actual: <N> passed, <M> failed
 
 ## Reproduction (exactly the commands you ran)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: tests
 
-# Atlas CI: spin up Neo4j 5.26, run the 314-test suite + AGM
+# Atlas CI: spin up Neo4j 5.26, run the full suite + AGM
 # compliance check + the BusinessMemBench head-to-head matrix.
 # Every push and every PR must pass.
 
@@ -11,6 +11,21 @@ on:
     branches: [main, master]
 
 jobs:
+  windows-sqlite-and-unit:
+    name: windows py3.14 unit + sqlite lifecycle
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+          cache: pip
+      - name: Install
+        run: python -m pip install -e .[dev]
+      - name: Run unit tests
+        run: python -m pytest tests/unit -q
+
   test:
     name: py${{ matrix.python-version }} + neo4j
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,25 +38,31 @@ Every line is real Neo4j + real ledger. No mocks. ~6s on subsequent runs. **This
 
 ### What you should see
 
-The last lines of `./demo.sh` should look like this — if they don't, file an issue:
+The final stages of `./demo.sh` should look like this — if they don't, file an issue:
 
 ```text
-[3/6] Triggering Ripple cascade ...
-        impacted nodes:               1
-        reassessment proposals:       1
-        contradictions:               0
+▶ Stage 4 / 7 — RippleEngine.propagate()
+  ✓ cascade complete
+  impacted nodes: 2
+  contradictions: 0
+  routing — auto: 2, strategic: 0, core: 0
 
-[4/6] Resolving via AGM revise() ...
-        belief.confidence_score:      0.88 -> 0.77
+▶ Stage 5 / 7 — Reassessment proposals
+  1. kref://AtlasDemo/Beliefs/origins_accessible.belief
+     0.88 → 0.74  (-0.14)
+  2. kref://AtlasDemo/Decisions/marketing_to_newcomers.decision
+     0.80 → 0.66  (-0.14)
 
-[5/6] Verifying ledger ...
-        chain intact:                 True
-        last_verified_sequence:       1   (the 1 fact promoted to ledger this run)
+▶ Stage 6 / 7 — Resolve one through adjudication
+  ✓ resolved with decision='accept'
 
-[6/6] LOOP CLOSED.
+▶ Stage 7 / 7 — Verify SHA-256 ledger chain
+  ✓ chain intact at sequence 1
+
+LOOP CLOSED.
 ```
 
-`last_verified_sequence: 1` looks small because the demo plants exactly one promotion-eligible fact and verifies the chain holds with one entry — every later run extends the chain and the number grows. The point is the chain *intact*, not the count.
+`last_verified_sequence = 1` looks small because the demo plants exactly one promotion-eligible fact and verifies the chain holds with one entry — every later run extends the chain and the number grows. The point is the chain *intact*, not the count.
 
 ### What Atlas is not
 

--- a/atlas_core/ingestion/base.py
+++ b/atlas_core/ingestion/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -18,6 +19,16 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+def default_data_dir() -> Path:
+    """Resolve Atlas runtime state at instance creation time."""
+    return Path(os.environ.get("ATLAS_DATA_DIR", str(Path.home() / ".atlas"))).expanduser()
+
+
+def default_cursor_dir() -> Path:
+    """Keep ingestion cursors isolated with the selected Atlas data dir."""
+    return default_data_dir() / "state"
 
 
 class StreamType(str, Enum):
@@ -113,7 +124,7 @@ class StreamConfig:
     cadence_seconds: int = 1800  # default 30 min
     max_events_per_run: int = 5000
     confidence_floor: float = 0.4
-    cursor_dir: Path = Path.home() / ".atlas" / "state"
+    cursor_dir: Path = field(default_factory=default_cursor_dir)
     daily_token_budget_usd: float = 5.0
 
 

--- a/atlas_core/ingestion/extractors/llm_base.py
+++ b/atlas_core/ingestion/extractors/llm_base.py
@@ -88,6 +88,13 @@ class LLMExtractor:
     def _ensure_client(self):
         if self._client is not None:
             return
+        from dotenv import find_dotenv, load_dotenv
+
+        # Respect exported variables, while making the documented repo-local
+        # .env file work for both CLI entrypoints and direct Python API use.
+        env_path = find_dotenv(usecwd=True)
+        if env_path:
+            load_dotenv(env_path, override=False)
         api_key = os.environ.get("ANTHROPIC_API_KEY")
         if not api_key:
             raise RuntimeError(

--- a/atlas_core/ingestion/vault.py
+++ b/atlas_core/ingestion/vault.py
@@ -122,7 +122,9 @@ class VaultExtractor(BaseExtractor):
             if not root.exists():
                 continue
             for path in root.rglob("*.md"):
-                rel = str(path.relative_to(root))
+                # krefs and ignore patterns are platform-independent.  Store
+                # vault-relative paths with forward slashes even on Windows.
+                rel = path.relative_to(root).as_posix()
                 if any(pattern in rel for pattern in VAULT_IGNORE_PATTERNS):
                     continue
 

--- a/atlas_core/trust/ledger.py
+++ b/atlas_core/trust/ledger.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import sqlite3
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -166,10 +167,20 @@ class HashChainedLedger:
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
+    @contextmanager
+    def _connection(self):
+        """Yield a connection and always release its SQLite file handle."""
+        conn = self._connect()
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
+
     def _init_schema(self) -> None:
         schema_path = Path(__file__).parent / "schemas" / "ledger.schema.sql"
         schema_sql = schema_path.read_text(encoding="utf-8")
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.executescript(schema_sql)
 
     # ── Append API ──────────────────────────────────────────────────────────
@@ -209,7 +220,7 @@ class HashChainedLedger:
         payload_json = _canonical_json(payload)
         metadata_json = _canonical_json(metadata or {})
 
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 last = conn.execute(
@@ -314,7 +325,7 @@ class HashChainedLedger:
         Returns ChainVerificationResult with first breakage point if any.
         Also writes an entry to the chain_verifications audit table.
         """
-        with self._connect() as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 """
                 SELECT chain_sequence, event_id, previous_hash,
@@ -424,7 +435,7 @@ class HashChainedLedger:
     def _record_verification(
         self, *, last_seq: int, last_id: str, intact: bool, notes: str
     ) -> None:
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO chain_verifications (
@@ -445,7 +456,7 @@ class HashChainedLedger:
 
         Used by AtlasGraphiti.add_episode to gate Ripple — only ledger
         entries trigger Ripple cascades."""
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 """
                 SELECT 1 FROM change_events
@@ -459,7 +470,7 @@ class HashChainedLedger:
         return row is not None
 
     def get_event(self, event_id: str) -> dict[str, Any] | None:
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT * FROM change_events WHERE event_id = ?", (event_id,)
             ).fetchone()
@@ -467,7 +478,7 @@ class HashChainedLedger:
 
     def get_root_lineage(self, root_id: str) -> list[dict[str, Any]]:
         """All events for a given root, oldest first."""
-        with self._connect() as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 """
                 SELECT * FROM change_events
@@ -480,21 +491,21 @@ class HashChainedLedger:
 
     def get_typed_root_state(self, root_id: str) -> dict[str, Any] | None:
         """Read materialized current state for a root."""
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT * FROM typed_roots WHERE root_id = ?", (root_id,)
             ).fetchone()
         return dict(row) if row else None
 
     def chain_length(self) -> int:
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) AS n FROM change_events"
             ).fetchone()
         return int(row["n"])
 
     def latest_event(self) -> dict[str, Any] | None:
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT * FROM change_events ORDER BY chain_sequence DESC LIMIT 1"
             ).fetchone()

--- a/atlas_core/trust/quarantine.py
+++ b/atlas_core/trust/quarantine.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 import sqlite3
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -314,10 +315,25 @@ class QuarantineStore:
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
+    @contextmanager
+    def _connection(self):
+        """Yield a connection and always close its OS handle.
+
+        ``sqlite3.Connection`` commits or rolls back when used as a context
+        manager, but it does not close itself.  That difference is observable
+        on Windows, where an open handle prevents TemporaryDirectory cleanup.
+        """
+        conn = self._connect()
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
+
     def _init_schema(self) -> None:
         schema_path = Path(__file__).parent / "schemas" / "candidates.schema.sql"
         schema_sql = schema_path.read_text(encoding="utf-8")
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.executescript(schema_sql)
 
     # ── Public API ──────────────────────────────────────────────────────────
@@ -343,7 +359,7 @@ class QuarantineStore:
         risk_level = _classify_risk(claim)
         now = _utc_now()
 
-        with self._connect() as conn:
+        with self._connection() as conn:
             existing = conn.execute(
                 "SELECT * FROM candidates WHERE fingerprint = ?", (fingerprint,)
             ).fetchone()
@@ -480,7 +496,7 @@ class QuarantineStore:
         writing the ledger event first; this just updates the candidate row.
         """
         now = _utc_now()
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE candidates
@@ -509,7 +525,7 @@ class QuarantineStore:
     ) -> None:
         """Mark candidate as denied (terminal)."""
         now = _utc_now()
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE candidates
@@ -530,7 +546,7 @@ class QuarantineStore:
             )
 
     def get_candidate(self, candidate_id: str) -> dict[str, Any] | None:
-        with self._connect() as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT * FROM candidates WHERE candidate_id = ?", (candidate_id,)
             ).fetchone()
@@ -544,12 +560,12 @@ class QuarantineStore:
             sql += " AND lane = ?"
             params.append(lane)
         sql += " ORDER BY created_at ASC"
-        with self._connect() as conn:
+        with self._connection() as conn:
             rows = conn.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
 
     def list_requires_approval(self) -> list[dict[str, Any]]:
-        with self._connect() as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 "SELECT * FROM candidates WHERE status = ? ORDER BY created_at ASC",
                 (CandidateStatus.REQUIRES_APPROVAL.value,),
@@ -567,7 +583,7 @@ class QuarantineStore:
         """Push a failed extraction into the dead letter queue. Returns DLQ id."""
         now = _utc_now()
         dlq_id = _new_ulid()
-        with self._connect() as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO om_dead_letter_queue (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "rapidfuzz>=3.6",
     "pyyaml>=6.0",
     "httpx>=0.27",
+    "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/test_adjudicate_cli.py
+++ b/tests/integration/test_adjudicate_cli.py
@@ -82,7 +82,7 @@ def _seed_candidate(
     cols = ", ".join(payload.keys())
     placeholders = ", ".join("?" * len(payload))
     now = "2026-04-29T00:00:00Z"
-    with quarantine._connect() as conn:
+    with quarantine._connection() as conn:
         conn.execute(
             f"INSERT INTO candidates ({cols}, created_at, updated_at) "
             f"VALUES ({placeholders}, ?, ?)",

--- a/tests/unit/test_ingestion.py
+++ b/tests/unit/test_ingestion.py
@@ -27,6 +27,13 @@ def write_md(path: Path, body: str) -> None:
 
 
 class TestCursorPersistence:
+    def test_default_cursor_follows_atlas_data_dir(self, tmp_path, monkeypatch):
+        from atlas_core.ingestion.base import StreamConfig
+
+        data_dir = tmp_path / "isolated-atlas"
+        monkeypatch.setenv("ATLAS_DATA_DIR", str(data_dir))
+        assert StreamConfig().cursor_dir == data_dir / "state"
+
     def test_fresh_cursor_when_no_file(self, tmp_dir, quarantine):
         from atlas_core.ingestion import VaultExtractor
         from atlas_core.ingestion.base import StreamConfig

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -10,7 +10,6 @@ This is the cryptographic core of Atlas's trust layer. Coverage includes:
   - Atomic append (no chain gaps)
 """
 
-import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -198,7 +197,7 @@ class TestVerifyChain:
                 payload={"v": i + 1},
             )
         # Tamper with the second event's payload
-        with sqlite3.connect(tmp_ledger.db_path) as conn:
+        with tmp_ledger._connection() as conn:
             conn.execute(
                 "UPDATE change_events SET payload_json = ? WHERE chain_sequence = 2",
                 ('{"v":999}',),
@@ -224,7 +223,7 @@ class TestVerifyChain:
             )
         # Tamper: overwrite event_id at seq 2 with a fake hash
         fake = "0" * 64
-        with sqlite3.connect(tmp_ledger.db_path) as conn:
+        with tmp_ledger._connection() as conn:
             conn.execute(
                 "UPDATE change_events SET event_id = ? WHERE chain_sequence = 2",
                 (fake,),
@@ -252,7 +251,7 @@ class TestVerifyChain:
                 root_id="kref://test/x.belief",
                 payload={"v": i + 1},
             )
-        with sqlite3.connect(tmp_ledger.db_path) as conn:
+        with tmp_ledger._connection() as conn:
             conn.execute(
                 "UPDATE change_events SET previous_hash = ? WHERE chain_sequence = 2",
                 ("a" * 64,),
@@ -397,7 +396,7 @@ class TestVerificationAudit:
         )
         tmp_ledger.verify_chain()
 
-        with sqlite3.connect(tmp_ledger.db_path) as conn:
+        with tmp_ledger._connection() as conn:
             count = conn.execute(
                 "SELECT COUNT(*) FROM chain_verifications"
             ).fetchone()[0]

--- a/tests/unit/test_llm_extractors.py
+++ b/tests/unit/test_llm_extractors.py
@@ -64,6 +64,17 @@ class TestTokenBudget:
 
 
 class TestLLMExtractorBase:
+    def test_client_loads_documented_dotenv_file(self, tmp_path, monkeypatch):
+        from atlas_core.ingestion.extractors.llm_base import LLMExtractor
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=from-dotenv\n")
+
+        extractor = LLMExtractor()
+        extractor._ensure_client()
+        assert extractor._client.api_key == "from-dotenv"
+
     def test_load_prompt_template_finds_vault(self):
         from atlas_core.ingestion.extractors import load_prompt_template
         text = load_prompt_template("vault")

--- a/tests/unit/test_sqlite_lifecycle.py
+++ b/tests/unit/test_sqlite_lifecycle.py
@@ -1,0 +1,20 @@
+"""Cross-platform regression tests for SQLite handle lifecycle."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def test_store_handles_are_released_before_tempdir_cleanup() -> None:
+    from atlas_core.trust import HashChainedLedger, QuarantineStore
+
+    with TemporaryDirectory() as temp:
+        root = Path(temp)
+        quarantine = QuarantineStore(root / "candidates.db")
+        ledger = HashChainedLedger(root / "ledger.db")
+
+        assert quarantine.list_pending() == []
+        assert ledger.verify_chain().intact is True
+
+    # Windows raises PermissionError at context exit if either connection is
+    # still open. Reaching this assertion is the regression contract.
+    assert not root.exists()

--- a/tests/unit/test_vault_roots_env.py
+++ b/tests/unit/test_vault_roots_env.py
@@ -81,5 +81,6 @@ def test_tilde_expansion(tmp_path: Path, monkeypatch):
     home = tmp_path / "home"
     (home / "vault").mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     env = {"ATLAS_VAULT_ROOTS": "~/vault"}
     assert resolve_vault_roots(env) == [home / "vault"]


### PR DESCRIPTION
## What this fixes

- closes #17 by explicitly closing SQLite connections and adding a Windows temp-directory regression
- closes #18 by deriving cursor state from `ATLAS_DATA_DIR/state`
- closes #20 by loading the documented `.env` for direct LLM extractor use
- closes #21 by syncing the README to the live seven-stage demo output
- adds a genuine Windows Python 3.14 unit/SQLite lifecycle CI job
- removes stale hard-coded suite counts from contributor-facing text

## Verification

- `ruff check atlas_core tests benchmarks scripts`
- `pytest tests/ -q` — 524 passed
- AGM compliance test module — 3 passed; 49/49 scenario contract unchanged
- BusinessMemBench — Atlas 1.000, 149/149 perfect
- `./demo.sh --reset` — loop closed, chain intact
- `scripts/doctor.py` — all checks passed

## Scope

Issue #19 is a larger ingestion-to-graph architecture gap and is intentionally reserved for a separate reviewed PR.