### PR TITLE
Fix approved claims never entering Neo4j

### DIFF
--- a/atlas_core/ingestion/__init__.py
+++ b/atlas_core/ingestion/__init__.py
@@ -49,6 +49,12 @@ from atlas_core.ingestion.imessage import (
     ImessageNotConfiguredError,
 )
 from atlas_core.ingestion.limitless import LimitlessExtractor
+from atlas_core.ingestion.materializer import (
+    MaterializationReport,
+    belief_kref_for_candidate,
+    materialize_approved_candidates,
+    materialize_candidate,
+)
 from atlas_core.ingestion.orchestrator import (
     IngestionOrchestrator,
     OrchestrationReport,
@@ -66,6 +72,10 @@ __all__ = [
     "STREAM_CONFIDENCE_FLOORS",
     "VaultExtractor",
     "LimitlessExtractor",
+    "MaterializationReport",
+    "belief_kref_for_candidate",
+    "materialize_candidate",
+    "materialize_approved_candidates",
     "ScreenpipeExtractor",
     "ClaudeSessionExtractor",
     "FirefliesExtractor",

--- a/atlas_core/ingestion/materializer.py
+++ b/atlas_core/ingestion/materializer.py
@@ -1,0 +1,126 @@
+"""Idempotent bridge from ledger-approved candidates to the Neo4j graph.
+
+The ledger remains the canonical trust decision.  This module projects that
+decision into Neo4j so the open-source ingest -> adjudicate path actually
+produces graph beliefs.  A failed graph write never erases ledger approval;
+rerunning the materializer safely retries the same candidate without creating
+duplicates.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from atlas_core.revision.uri import Kref
+
+if TYPE_CHECKING:
+    from neo4j import AsyncDriver
+
+    from atlas_core.trust import QuarantineStore
+
+
+@dataclass
+class MaterializationReport:
+    attempted: int = 0
+    materialized: int = 0
+    failed: int = 0
+    belief_krefs: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def belief_kref_for_candidate(candidate: dict[str, Any]) -> str:
+    """Mint one stable belief kref per deduplicated candidate."""
+    subject = Kref.parse(candidate["subject_kref"])
+    return (
+        f"kref://{subject.project}/IngestedBeliefs/"
+        f"candidate_{candidate['candidate_id']}.belief"
+    )
+
+
+async def materialize_candidate(
+    driver: AsyncDriver,
+    candidate: dict[str, Any],
+) -> str:
+    """Upsert one approved candidate as ``(:Belief)-[:ABOUT]->(:AtlasItem)``."""
+    if candidate.get("status") != "approved" or not candidate.get("ledger_event_id"):
+        raise ValueError("candidate must be ledger-approved before graph materialization")
+
+    subject = Kref.parse(candidate["subject_kref"])
+    belief_kref = belief_kref_for_candidate(candidate)
+    now = datetime.now(timezone.utc).isoformat()
+    evidence_json = candidate.get("evidence_refs_json") or "[]"
+    # Validate before sending the serialized evidence into Neo4j.
+    json.loads(evidence_json)
+
+    cypher = """
+    MERGE (subject:AtlasItem {kref: $subject_kref})
+      ON CREATE SET subject.created_at = $now,
+                    subject.kind = $subject_kind,
+                    subject.deprecated = false
+    MERGE (belief:AtlasItem:Belief {candidate_id: $candidate_id})
+      ON CREATE SET belief.kref = $belief_kref,
+                    belief.created_at = $now,
+                    belief.materialized_at = $now,
+                    belief.deprecated = false
+    SET belief.predicate = $predicate,
+        belief.object_value = $object_value,
+        belief.text = $text,
+        belief.assertion_type = $assertion_type,
+        belief.confidence_score = $confidence,
+        belief.trust_score = $trust_score,
+        belief.scope = $scope,
+        belief.lane = $lane,
+        belief.ledger_event_id = $ledger_event_id,
+        belief.evidence_refs_json = $evidence_json,
+        belief.last_materialized_at = $now
+    MERGE (belief)-[about:ABOUT]->(subject)
+      ON CREATE SET about.created_at = $now
+    RETURN belief.kref AS belief_kref
+    """
+    async with driver.session() as session:
+        result = await session.run(
+            cypher,
+            subject_kref=subject.root_kref().to_string(),
+            subject_kind=subject.kind,
+            belief_kref=belief_kref,
+            candidate_id=candidate["candidate_id"],
+            predicate=candidate["predicate"],
+            object_value=candidate["object_value"],
+            text=f"{candidate['predicate']}: {candidate['object_value']}",
+            assertion_type=candidate["assertion_type"],
+            confidence=float(candidate["confidence"]),
+            trust_score=float(candidate["trust_score"]),
+            scope=candidate["scope"],
+            lane=candidate["lane"],
+            ledger_event_id=candidate["ledger_event_id"],
+            evidence_json=evidence_json,
+            now=now,
+        )
+        record = await result.single()
+    if record is None:
+        raise RuntimeError(f"Neo4j returned no belief for {candidate['candidate_id']}")
+    return str(record["belief_kref"])
+
+
+async def materialize_approved_candidates(
+    driver: AsyncDriver,
+    quarantine: QuarantineStore,
+) -> MaterializationReport:
+    """Project every approved candidate; continue and report per-item failures."""
+    report = MaterializationReport()
+    for candidate in quarantine.list_approved():
+        report.attempted += 1
+        try:
+            belief_kref = await materialize_candidate(driver, candidate)
+        except Exception as exc:
+            report.failed += 1
+            report.errors.append(
+                f"{candidate['candidate_id']}: {type(exc).__name__}: {exc}"
+            )
+            continue
+        report.materialized += 1
+        report.belief_krefs.append(belief_kref)
+    return report

--- a/atlas_core/trust/quarantine.py
+++ b/atlas_core/trust/quarantine.py
@@ -572,6 +572,15 @@ class QuarantineStore:
             ).fetchall()
         return [dict(r) for r in rows]
 
+    def list_approved(self) -> list[dict[str, Any]]:
+        """Return ledger-approved candidates awaiting or eligible for graph sync."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM candidates WHERE status = ? ORDER BY promoted_at ASC",
+                (CandidateStatus.APPROVED.value,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
     def upsert_dead_letter(
         self,
         *,

--- a/docs/INSTALL_MODES.md
+++ b/docs/INSTALL_MODES.md
@@ -82,11 +82,12 @@ Run the full pipeline once to seed (the daemon module runs one ingestion cycle p
 PYTHONPATH=. python -m atlas_core.daemon.cycle
 ```
 
-This walks the vault, quarantines new claims, promotes corroborated ones to
-the ledger, and runs Ripple on each promotion. The adjudication queue
-appears as markdown files under `~/.atlas/adjudication/` — open that folder
-in Obsidian alongside your main vault, and resolved entries archive to
-`~/.atlas/adjudication/archive/`.
+This walks the vault and quarantines new claims. Then run
+`python scripts/adjudicate.py --all` to promote eligible claims to the ledger
+and project every approved claim into Neo4j as a belief linked to its subject.
+The adjudication queue appears as markdown files under
+`~/.atlas/adjudication/` — open that folder in Obsidian alongside your main
+vault, and resolved entries archive to `~/.atlas/adjudication/archive/`.
 
 What you get:
 - LLM-driven extraction from free-text notes (uses Claude via the

--- a/docs/PROPOSAL_VS_MUTATION.md
+++ b/docs/PROPOSAL_VS_MUTATION.md
@@ -87,7 +87,8 @@ stays sharp.
 | Method | Class | What it does |
 |---|---|---|
 | `QuarantineStore.upsert_candidate(claim, ...)` | **MUTATION (non-graph)** | Writes / merges a candidate row in the quarantine SQLite DB. Computes trust score, may auto-promote to `auto_promoted` status. **Does not touch the typed graph** — promotion to graph happens later via `promote_candidate` chained through `revise`. |
-| `QuarantineStore.promote_candidate(candidate_id, ...)` | **MUTATION (non-graph)** | Marks the candidate as promoted in SQLite, may chain to `ledger.append_event`. **Still does not write to the typed graph by itself** — the caller (typically the orchestrator) is responsible for invoking `revise()` separately if a graph node should land. |
+| `QuarantineStore.promote_candidate(candidate_id, ...)` | **MUTATION (non-graph)** | Marks the candidate as promoted in SQLite after `ledger.append_event`. Graph projection is a separate, retryable materializer step. |
+| `materialize_approved_candidates(driver, quarantine)` | **MUTATION** | Idempotently projects every ledger-approved candidate as `(:Belief)-[:ABOUT]->(:AtlasItem)` in Neo4j. Ledger approval remains canonical; failed projections are reported and safe to retry. |
 | `QuarantineStore.deny_candidate(...)` | **MUTATION (non-graph)** | SQLite status update only. |
 | `QuarantineStore.upsert_dead_letter(...)` | **MUTATION (non-graph)** | SQLite write to the dead-letter table. |
 | `QuarantineStore.list_pending(...)` / `list_requires_approval(...)` / `get_candidate(...)` | **READ-ONLY** | SQLite reads. |

--- a/scripts/adjudicate.py
+++ b/scripts/adjudicate.py
@@ -2,13 +2,13 @@
 
 Atlas extracts claims into a quarantine pool tagged `requires_approval`.
 Until they're moved out of quarantine — either promoted to the canonical
-ledger or denied — Ripple has nothing to walk on and Atlas can't produce
-contradictions, lineage, or any of its propagation-aware behavior.
+ledger and projected into Neo4j, or denied — Atlas's trusted graph remains
+incomplete and downstream graph analysis cannot see those claims.
 
 This CLI is the human-in-the-loop unblocker. It does three things:
 
   • Auto-promote: candidates above the verification floor (0.80 by
-    default) and on a trusted lane go straight into the ledger.
+    default) and on a trusted lane go into the ledger, then Neo4j.
   • Queue: candidates below the floor are written as Markdown files to
     the adjudication queue (an Obsidian-readable folder) so the user can
     resolve them by editing `decision: accept|reject|adjust` in the
@@ -19,7 +19,8 @@ This CLI is the human-in-the-loop unblocker. It does three things:
 Usage:
     python scripts/adjudicate.py --report                     # show buckets, no changes
     python scripts/adjudicate.py --auto-promote --dry-run     # preview ledger writes
-    python scripts/adjudicate.py --auto-promote               # apply promotions
+    python scripts/adjudicate.py --auto-promote               # ledger + graph
+    python scripts/adjudicate.py --materialize                # retry graph projection
     python scripts/adjudicate.py --queue                      # write queue entries
     python scripts/adjudicate.py --auto-deny                  # deny noise candidates
     python scripts/adjudicate.py --all                        # promote + queue + deny
@@ -31,6 +32,7 @@ queue everything between 0.50 and 0.80, deny below 0.50.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
 import os
@@ -74,6 +76,8 @@ class Counts:
     queued: int = 0
     denied: int = 0
     skipped: int = 0
+    materialized: int = 0
+    materialize_failed: int = 0
 
 
 def _safe_filename(text: str, max_len: int = 80) -> str:
@@ -260,6 +264,26 @@ def auto_deny(
     return counts
 
 
+async def materialize_from_env(quarantine: QuarantineStore):
+    """Connect to configured Neo4j and retry every ledger-approved candidate."""
+    from neo4j import AsyncGraphDatabase
+
+    from atlas_core.ingestion import materialize_approved_candidates
+
+    driver = AsyncGraphDatabase.driver(
+        os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
+        auth=(
+            os.environ.get("NEO4J_USER", "neo4j"),
+            os.environ.get("NEO4J_PASSWORD", "atlasdev"),
+        ),
+    )
+    try:
+        await driver.verify_connectivity()
+        return await materialize_approved_candidates(driver, quarantine)
+    finally:
+        await driver.close()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument(
@@ -288,6 +312,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--auto-deny", action="store_true")
     parser.add_argument("--all", action="store_true",
                         help="Equivalent to --auto-promote --queue --auto-deny")
+    parser.add_argument(
+        "--materialize", action="store_true",
+        help="Retry projection of all ledger-approved candidates into Neo4j",
+    )
+    parser.add_argument(
+        "--ledger-only", action="store_true",
+        help="Promote to the ledger without graph projection (explicit partial loop)",
+    )
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview without mutating any state")
     parser.add_argument("--verbose", "-v", action="store_true")
@@ -309,7 +341,10 @@ def main(argv: list[str] | None = None) -> int:
     policy = PromotionPolicy(quarantine=quarantine, ledger=ledger)
 
     # Default action when no flags: report
-    if not any([args.report, args.auto_promote, args.queue, args.auto_deny, args.all]):
+    if not any([
+        args.report, args.auto_promote, args.queue, args.auto_deny,
+        args.all, args.materialize,
+    ]):
         args.report = True
 
     if args.report:
@@ -336,6 +371,7 @@ def main(argv: list[str] | None = None) -> int:
     do_promote = args.auto_promote or args.all
     do_queue = args.queue or args.all
     do_deny = args.auto_deny or args.all
+    do_materialize = args.materialize or (do_promote and not args.ledger_only)
 
     grand = Counts()
     if do_promote:
@@ -357,15 +393,31 @@ def main(argv: list[str] | None = None) -> int:
             quarantine=quarantine, noise_floor=args.noise_floor, dry_run=args.dry_run,
         )
         grand.denied += c.denied
+    if do_materialize and not args.dry_run:
+        try:
+            report = asyncio.run(materialize_from_env(quarantine))
+        except Exception as exc:
+            print(
+                f"materialization failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            grand.materialize_failed += 1
+        else:
+            grand.materialized += report.materialized
+            grand.materialize_failed += report.failed
+            for error in report.errors:
+                print(f"materialization failed: {error}", file=sys.stderr)
 
     prefix = "DRY-RUN " if args.dry_run else ""
     print(
         f"\n{prefix}adjudication summary: "
         f"promoted={grand.promoted} (failed={grand.promoted_failed}) "
         f"queued={grand.queued} (skipped={grand.skipped}) "
-        f"denied={grand.denied}\n"
+        f"denied={grand.denied} "
+        f"materialized={grand.materialized} "
+        f"(failed={grand.materialize_failed})\n"
     )
-    return 0
+    return 2 if grand.promoted_failed or grand.materialize_failed else 0
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_adjudicate_cli.py
+++ b/tests/integration/test_adjudicate_cli.py
@@ -1,10 +1,11 @@
 """Integration tests for scripts/adjudicate.py.
 
-Exercises the three modes (auto-promote, queue, auto-deny) against a
+Exercises the adjudication modes (auto-promote, materialize, queue, auto-deny) against a
 fresh QuarantineStore + HashChainedLedger seeded with synthetic
 candidates. Confirms:
 
   - High-confidence vault candidates are promoted to ledger atomically.
+  - A promotion run invokes graph materialization unless ledger-only is explicit.
   - Medium-confidence candidates get rendered as Markdown queue entries
     with valid frontmatter.
   - Low-confidence candidates get terminal-denied.
@@ -161,6 +162,64 @@ def test_auto_promote_dry_run_mutates_nothing(stores):
     candidate = stores["quarantine"].get_candidate("DRY")
     assert candidate is not None
     assert candidate["status"] == "requires_approval"
+
+
+def test_cli_auto_promote_materializes_by_default(stores, monkeypatch):
+    """The public CLI closes the ledger -> graph loop after promotion."""
+    adj = _load_adjudicate()
+    _seed_candidate(
+        stores["quarantine"],
+        candidate_id="GRAPH1",
+        lane="atlas_vault",
+        confidence=0.95,
+    )
+    calls = []
+
+    async def fake_materialize(quarantine):
+        calls.append(quarantine.list_approved())
+        return MaterializationReport(
+            attempted=1,
+            materialized=1,
+            belief_krefs=["kref://Atlas/IngestedBeliefs/candidate_GRAPH1.belief"],
+        )
+
+    from atlas_core.ingestion import MaterializationReport
+
+    monkeypatch.setattr(adj, "materialize_from_env", fake_materialize)
+
+    exit_code = adj.main([
+        "--data-dir", str(stores["data_dir"]),
+        "--auto-promote",
+    ])
+
+    assert exit_code == 0
+    assert len(calls) == 1
+    assert [candidate["candidate_id"] for candidate in calls[0]] == ["GRAPH1"]
+
+
+def test_cli_ledger_only_skips_materialization(stores, monkeypatch):
+    """Operators can deliberately stop at the canonical ledger."""
+    adj = _load_adjudicate()
+    _seed_candidate(
+        stores["quarantine"],
+        candidate_id="LEDGER1",
+        lane="atlas_vault",
+        confidence=0.95,
+    )
+
+    async def fail_if_called(_quarantine):
+        raise AssertionError("materializer should not run")
+
+    monkeypatch.setattr(adj, "materialize_from_env", fail_if_called)
+
+    exit_code = adj.main([
+        "--data-dir", str(stores["data_dir"]),
+        "--auto-promote",
+        "--ledger-only",
+    ])
+
+    assert exit_code == 0
+    assert stores["quarantine"].get_candidate("LEDGER1")["status"] == "approved"
 
 
 def test_queue_writes_markdown_file(stores, tmp_path):

--- a/tests/integration/test_candidate_materialization.py
+++ b/tests/integration/test_candidate_materialization.py
@@ -1,0 +1,94 @@
+"""Approved ingestion candidates must become idempotent Neo4j beliefs."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def driver():
+    from neo4j import AsyncGraphDatabase
+
+    drv = AsyncGraphDatabase.driver(
+        os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
+        auth=(
+            os.environ.get("NEO4J_USER", "neo4j"),
+            os.environ.get("NEO4J_PASSWORD", "atlasdev"),
+        ),
+    )
+    try:
+        await drv.verify_connectivity()
+        yield drv
+    finally:
+        await drv.close()
+
+
+async def test_approved_candidate_materializes_once_with_about_edge(driver, tmp_path):
+    from atlas_core.ingestion import materialize_approved_candidates
+    from atlas_core.trust import (
+        CandidateClaim,
+        EvidenceRef,
+        HashChainedLedger,
+        PromotionPolicy,
+        QuarantineStore,
+    )
+
+    project = f"AtlasMaterialize_{uuid.uuid4().hex[:8]}"
+    subject_kref = f"kref://{project}/Programs/zenith.program"
+    quarantine = QuarantineStore(tmp_path / "candidates.db")
+    ledger = HashChainedLedger(tmp_path / "ledger.db")
+    upsert = quarantine.upsert_candidate(CandidateClaim(
+        lane="atlas_vault",
+        assertion_type="factual_assertion",
+        subject_kref=subject_kref,
+        predicate="pricing_belief",
+        object_value="$3,495",
+        confidence=0.95,
+        evidence_ref=EvidenceRef(
+            source="test",
+            source_family="vault",
+            kref=f"kref://{project}/Vault/pricing.note",
+            timestamp="2026-07-16T00:00:00+00:00",
+        ),
+    ), auto_promote_enabled=False)
+    promoted = PromotionPolicy(quarantine=quarantine, ledger=ledger).promote(
+        upsert.candidate_id,
+        actor_id="test.materializer",
+    )
+    assert promoted.promoted is True
+    assert len(quarantine.list_approved()) == 1
+
+    try:
+        first = await materialize_approved_candidates(driver, quarantine)
+        second = await materialize_approved_candidates(driver, quarantine)
+        assert first.materialized == 1 and first.failed == 0
+        assert second.materialized == 1 and second.failed == 0
+        assert first.belief_krefs == second.belief_krefs
+
+        async with driver.session() as session:
+            result = await session.run(
+                "MATCH (b:Belief {candidate_id: $cid})-[r:ABOUT]->"
+                "(s:AtlasItem {kref: $subject}) "
+                "RETURN count(b) AS beliefs, count(r) AS edges, "
+                "b.ledger_event_id AS ledger_event_id, "
+                "b.object_value AS object_value",
+                cid=upsert.candidate_id,
+                subject=subject_kref,
+            )
+            row = await result.single()
+        assert row is not None
+        assert row["beliefs"] == 1
+        assert row["edges"] == 1
+        assert row["ledger_event_id"] == promoted.ledger_event.event_id
+        assert row["object_value"] == "$3,495"
+    finally:
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (n) WHERE n.kref STARTS WITH $prefix DETACH DELETE n",
+                prefix=f"kref://{project}/",
+            )


### PR DESCRIPTION
Closes #19.

## What changed
- add a retryable, idempotent bridge from ledger-approved candidates to Neo4j
- materialize each approved candidate as a typed `Belief` with an `ABOUT` link to its subject
- make `adjudicate.py --auto-promote` and `--all` close the ledger-to-graph loop by default
- retain an explicit `--ledger-only` escape hatch and add `--materialize` for retries
- report graph failures explicitly and return a non-zero exit code
- correct installation and mutation-boundary documentation

## Proof
- 527 tests passed
- focused CLI + live Neo4j materialization proof: 12 passed
- idempotency proof: two materialization passes produce exactly one belief and one `ABOUT` edge
- Ruff: all checks passed
- Atlas doctor: all checks passed
- AGM compliance: 49/49
- BusinessMemBench Atlas adapter: 149/149

Optional external BMB adapters remained skipped because their credentials or SDKs are not configured; they are unrelated to this change.
