### PR TITLE
Replace Hermes/OpenClaw adapter stubs with real local retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,29 @@ To save you time:
 - **Not yet a Letta replacement.** Atlas does not run agent loops. It plugs into agent runtimes as a memory backend. If you want an agent stack with memory built in, Letta or Hermes is the right answer; Atlas slots underneath.
 - **Not yet automatic free-text understanding at scale.** The ingestion pipeline works on real Limitless / Fireflies / Claude transcripts, but extraction quality on truly unstructured text is uneven and improving — see `atlas_core/ingestion/extractors/` for the prompt set we're iterating on.
 
+### Hermes and OpenClaw: real retrieval, honest boundary
+
+The adapter cores now perform real local `store`, `search` / `recall`, `get`,
+`list`, and `forget` operations against Atlas's SQLite trust store. This path
+does **not** require Neo4j, Docker, an embedding model, or an API key:
+
+```bash
+PYTHONPATH=. python scripts/demo_runtime_adapters.py
+```
+
+CI runs that proof with the Neo4j endpoint deliberately pointed at a dead port.
+The remaining boundary is packaging: current Hermes Agent uses its newer
+`MemoryProvider` lifecycle, and current OpenClaw uses a TypeScript plugin SDK.
+The Python modules in `atlas_core/adapters/` are functional SDK-neutral cores,
+not yet installable native packages for those latest upstream runtimes. The
+exact capability split and acceptance test are documented in
+[`docs/RUNTIME_ADAPTERS.md`](docs/RUNTIME_ADAPTERS.md).
+
 ### Who Atlas is for, today
 
 The strongest early users are:
 
-- **Agent / tool builders** who need a memory backend with belief-revision semantics (MCP server, Hermes plugin, OpenClaw plugin all ship in `atlas_core/adapters/`).
+- **Agent / tool builders** who need a memory backend with belief-revision semantics (MCP/HTTP surfaces plus tested Hermes/OpenClaw adapter cores ship today).
 - **Power users with Obsidian / transcripts / vaults** who want their meetings + screen + chat captures cross-checked for emergent contradictions.
 - **Local-first AI builders** who can't or won't ship user data to a cloud memory service.
 - **Researchers** working on belief revision, AGM compliance, or non-monotonic reasoning who want a reproducible, instrumented baseline.
@@ -161,7 +179,7 @@ If you're shopping memory backends for an agent system, here's how Atlas stacks 
 | **Automatic downstream reassessment (Ripple)** | ✅ | ❌ flag-only | ❌ | ❌ | ❌ | ❌ |
 | Domain-typed business ontology shipped | ✅ 8 entity types | ❌ | ❌ | ❌ | ❌ | partial |
 | Continuous multi-stream ingestion | ✅ 6 streams | ❌ SDK only | ❌ | ❌ | ❌ | partial |
-| Hermes / OpenClaw / Claude Code adapters | ✅ all 3 | partial | ❌ | partial | ❌ | ❌ |
+| Runtime integration | ✅ Claude MCP + functional Hermes/OpenClaw cores | partial | ❌ | partial | ❌ | ❌ |
 
 #### What Atlas does *worse* (today)
 
@@ -200,7 +218,7 @@ Honest accounting. Atlas's cost story shifts dramatically between v0.1.0a1 (toda
 **v0.1.0a1 (today): ≈ $0/month.**
 - Extractors are 100% deterministic — frontmatter parsing, YAML readers, regex pattern matching. No LLM calls.
 - Ripple's `HeuristicReassessor` (default) does no LLM call; it's a closed-form damped formula. The `LLMReassessor` exists but is opt-in and not the default.
-- Neo4j 5.26 runs locally in Docker. SQLite ledger is local. No telemetry, no cloud, no API keys.
+- The portable adapter-memory tier uses SQLite only. Neo4j 5.26 runs locally in Docker when graph revision and Ripple are enabled. No telemetry, cloud, or API keys are required.
 - The only ongoing cost is the electricity to keep your machine on.
 
 **Post-Tier-1.4 (LLM-driven extraction lands): bounded by your token budget.**
@@ -255,11 +273,15 @@ Re-runs are idempotent: 0.9s for the next cycle, with all duplicate claims finge
 # 1. Clone
 git clone https://github.com/RichSchefren/atlas && cd atlas
 
-# 2. Run Neo4j locally
+# 2a. Prove portable Hermes/OpenClaw storage + retrieval (no Docker)
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+PYTHONPATH=. python scripts/demo_runtime_adapters.py
+
+# 2b. Add the cognitive-graph tier (required for AGM + Ripple)
 docker compose up -d                               # bolt://localhost:7687
 
 # 3. Install — base is deterministic + $0/month; opt in to extras as you need them
-python -m venv .venv && source .venv/bin/activate
 pip install -e .              # core: AGM + Ripple + ledger + adapters + ingest
 # pip install -e ".[llm]"        # add Anthropic SDK for LLM-driven extraction
 # pip install -e ".[embeddings]" # add sentence-transformers (~2GB; rarely needed — vault-search is the default retrieval path)
@@ -267,7 +289,7 @@ pip install -e .              # core: AGM + Ripple + ledger + adapters + ingest
 # pip install -e ".[full]"       # everything above
 # pip install -e ".[dev]"        # contributor tooling (includes anthropic for tests)
 
-# 4. Verify with the test suite (518 tests, ~12s)
+# 4. Verify with the test suite (532 tests in this snapshot)
 PYTHONPATH=. pytest tests/ -v
 
 # 5. Reproduce AGM compliance (49/49 scenarios, ~30s)
@@ -289,7 +311,7 @@ ATLAS_VAULT_ROOTS=~/Vaults/business:~/Vaults/personal PYTHONPATH=. python script
 ┌──────────────────────────────────────────────────────────────┐
 │  ATLAS API LAYER                                             │
 │  MCP (13 tools) · FastAPI (:9879) · Kumiho-compatible gRPC    │
-│  + Hermes / OpenClaw / Claude Code plugins                   │
+│  + Hermes / OpenClaw cores + Claude Code MCP                 │
 └──────────────────────────────────────────────────────────────┘
                             │
 ┌──────────────────────────────────────────────────────────────┐
@@ -327,15 +349,18 @@ Full design docs are checked into the repo at [`paper/atlas.md`](paper/atlas.md)
 
 Atlas ships with three concurrent surfaces:
 
-- **MCP**: 13 Atlas-original tools — `ripple.analyze_impact`, `ripple.reassess`, `ripple.detect_contradictions`, `adjudication.queue`, `adjudication.resolve`, `quarantine.upsert`, `quarantine.list_pending`, `ledger.verify_chain`, `working_memory.assemble`, `lineage.walk`, `sharing.grant`, `sharing.revoke`, `sharing.list_grants`. Stdio JSON-RPC bridge for Claude Code via `python -m atlas_core.adapters.claude_code`. Read-only vs mutation classification at [`docs/PROPOSAL_VS_MUTATION.md`](docs/PROPOSAL_VS_MUTATION.md).
+- **MCP**: 17 Atlas-original tools — the graph/Ripple, adjudication, quarantine, ledger, working-memory, lineage, and sharing tools plus portable `memory.search`, `memory.get`, `memory.list`, and `memory.forget`. Stdio JSON-RPC bridge for Claude Code via `python -m atlas_core.adapters.claude_code`. Read-only vs mutation classification at [`docs/PROPOSAL_VS_MUTATION.md`](docs/PROPOSAL_VS_MUTATION.md).
 - **HTTP**: FastAPI on `localhost:9879` mirrors the MCP surface for non-MCP clients (the dashboard, curl, integration tests). Endpoints: `/health`, `/tools`, `/tools/{name}`, `/verify-chain`.
 - **gRPC** (Phase 2 W7+): scaffold with all 51 Kumiho-compatible RPC method names registered. Existing Kumiho SDK code switches to Atlas by setting `endpoint="localhost:50051"`.
 
-Plus runtime adapters (drop-in plugins):
+Plus runtime adapters:
 
 - `atlas_core.adapters.claude_code` — MCP stdio bridge for Claude Code
-- `atlas_core.adapters.hermes.AtlasHermesProvider` — NousResearch Hermes MemoryProvider
-- `atlas_core.adapters.openclaw.AtlasOpenClawPlugin` — OpenClaw memory plugin
+- `atlas_core.adapters.hermes.AtlasHermesProvider` — functional SQLite-backed Hermes-shaped core
+- `atlas_core.adapters.openclaw.AtlasOpenClawPlugin` — functional SQLite-backed OpenClaw-shaped core
+
+The latter two are not labeled current upstream-native packages; see
+[`docs/RUNTIME_ADAPTERS.md`](docs/RUNTIME_ADAPTERS.md).
 
 ---
 
@@ -427,15 +452,15 @@ If you want to break Atlas, [TESTING.md](TESTING.md) has five concrete paths fro
 | Working-memory block manager (Letta-style) | `pytest tests/unit/test_working_memory.py -v` |
 | Multi-tenant tenant context + sharing policy + federated adjudication | `pytest tests/unit/test_multi_tenant.py -v` |
 | Adjudication round-trip — markdown queue → AGM revise → ledger SUPERSEDE → archive | `pytest tests/integration/test_adjudication_resolver.py -v` |
-| 13 MCP tools dispatch correctly via stdio JSON-RPC | `pytest tests/integration/test_mcp_server.py tests/integration/test_claude_code_stdio.py -v` |
+| 17 MCP tools dispatch correctly via stdio JSON-RPC | `pytest tests/integration/test_mcp_server.py tests/integration/test_claude_code_stdio.py -v` |
 | FastAPI surface with CORS + Server-Sent Events stream | `pytest tests/integration/test_http_server.py tests/unit/test_events_broadcaster.py -v` |
-| Hermes / OpenClaw / Claude Code adapters at the contract level | `pytest tests/integration/test_adapters.py -v` |
+| Hermes/OpenClaw adapter storage, retrieval, fetch, list, and forget without Neo4j | `python scripts/demo_runtime_adapters.py` |
 | Kumiho-compat gRPC handlers (10 of 51 methods wired, 41 return UNIMPLEMENTED) | `pytest tests/integration/test_grpc_handlers.py -v` |
 | Property-based AGM testing (hypothesis-driven) | `pytest tests/unit/test_agm_property_based.py -v` |
 | BusinessMemBench at 1.000 vs Graphiti 0.711 on 149 deterministic questions | `python scripts/run_bmb.py` |
 | Live ingest from real machine state (vault + Limitless + Screenpipe + Claude) | `python scripts/first_real_run.py` |
 | launchd daemon installs (continuous ingestion + API server) | `./scripts/install_launchd.sh` |
-| **All of the above run together** | `pytest tests/ -v` (518 passing) |
+| **All of the above run together** | `pytest tests/ -v` (532 passing) |
 
 ### Planned — explicitly NOT done (no proof commands, by design)
 
@@ -444,7 +469,7 @@ If you want to break Atlas, [TESTING.md](TESTING.md) has five concrete paths fro
 | LoCoMo + LongMemEval **measured** numbers (not asserted) | Datasets are research-license; haven't been downloaded + run yet. Runners exist (`benchmarks/locomo/`, `benchmarks/longmemeval/`); just need someone with dataset access to fire them. |
 | Mem0 / Letta / Memori columns in BMB matrix | Adapters fail-loud without `OPENAI_API_KEY` / `MEMORI_API_KEY`. Set the keys + re-run `scripts/run_bmb.py` to fill the rows. |
 | 1,000-question BusinessMemBench (currently 149 deterministic) | The 200 human-authored gold subset (templates in `benchmarks/business_mem_bench/gold_human/`) needs domain-operator authors. The remaining 800 are LLM-expanded from templates — runner ready, expansion not yet executed. |
-| Live Hermes / OpenClaw round-trip in their actual upstream processes | Adapter code complete + tested; round-trip in a real `hermes-agent` / `openclaw` runtime requires cloning those upstreams and configuring Atlas as memory backend. |
+| Native latest-Hermes and latest-OpenClaw packages | Portable core is complete and tested; Hermes still needs a current `MemoryProvider` lifecycle wrapper ([#27](https://github.com/RichSchefren/atlas/issues/27)), and OpenClaw needs a TypeScript `registerMemoryCapability` package ([#26](https://github.com/RichSchefren/atlas/issues/26)). Neither will be called drop-in before a real upstream-process round trip passes. |
 | arxiv submission live | Tarball ready at `paper/arxiv/atlas-arxiv.tar.gz`. Submission goes through arxiv.org/submit (24-48h moderation). |
 | Confidence-threshold empirical calibration | Script exists at `scripts/calibrate_confidence_thresholds.py`. Needs a week of real ingest data before it produces a meaningful recommendation. |
 | Obsidian plugin in the Community Plugins registry | Plugin code complete at `obsidian-plugin/`. Manual install path documented; registry submission deferred. |
@@ -456,7 +481,7 @@ If a row in **Planned** is something you want sooner, file an issue describing t
 
 Atlas as v0.1.0a1 is roughly **70-80% of the full system** described in the Phase 0 design docs. See `PHASE-5-AND-BEYOND.md` for the tiered roadmap of what's left.
 
-Test count this snapshot: **518 passing** in CI against Ubuntu + Neo4j 5.26.
+Test count this snapshot: **532 passing** locally against Python 3.14 + Neo4j 5.26; the pull-request matrix independently verifies Python 3.10–3.14 and Windows.
 
 ---
 

--- a/atlas_core/adapters/__init__.py
+++ b/atlas_core/adapters/__init__.py
@@ -1,14 +1,15 @@
-"""Atlas adapters — drop-in plugins for agent runtimes.
+"""Atlas runtime adapters.
 
 Each adapter wraps AtlasMCPServer in the contract a target runtime expects:
 
   - claude_code  → JSON-RPC 2.0 over stdio (MCP spec)
-  - hermes       → MemoryProvider protocol (NousResearch hermes-agent)
-  - openclaw     → Memory plugin (OpenClawIO/openclaw)
+  - hermes       → functional SDK-neutral CRUD/retrieval core
+  - openclaw     → functional SDK-neutral CRUD/retrieval core
 
-All three share the same Atlas backend, so AGM revision and Ripple
-cascade behavior are identical across runtimes — Atlas is the substrate,
-runtimes are the consumer.
+The Hermes and OpenClaw cores provide real SQLite-backed storage, retrieval,
+listing, and forgetting without Neo4j. Current upstream-native wrappers are a
+separate packaging layer; see docs/RUNTIME_ADAPTERS.md. When Neo4j is enabled,
+the same Atlas substrate also exposes AGM revision and Ripple behavior.
 
 Spec: 09 - Agent Runtime Memory Competitive Landscape.md
 """

--- a/atlas_core/adapters/hermes.py
+++ b/atlas_core/adapters/hermes.py
@@ -1,20 +1,22 @@
-"""Hermes MemoryProvider adapter — Atlas as the 9th memory backend for
-NousResearch's Hermes agent runtime.
+"""SDK-neutral Hermes adapter core backed by Atlas's local memory tools.
 
-Hermes' MemoryProvider plugin contract (inferred from hermes-agent
-plugin/memory/*.py — the project ships 8 backends including ChromaDB, Qdrant,
-Weaviate, PostgreSQL, Redis, in-memory, JSON file, and SQLite). Each backend
-implements a 4-method protocol:
+The CRUD-shaped interface below was drafted against an older Hermes contract.
+It remains useful as a tested adapter core, but current Hermes Agent plugins
+subclass ``agent.memory_provider.MemoryProvider`` and use lifecycle hooks such
+as ``prefetch`` and ``sync_turn``.  Atlas does not describe this module as a
+drop-in current-Hermes plugin; the native wrapper belongs in a separately
+versioned integration package.
+
+This core now implements all four operations for real:
 
     async def put(item: MemoryItem) -> str            # returns item_id
     async def search(query: str, k: int) -> list[MemoryItem]
     async def get(item_id: str) -> MemoryItem | None
     async def delete(item_id: str) -> bool
 
-Atlas's differentiator: this is the only backend that runs AGM-compliant
-revision and Ripple reassessment under the hood. From Hermes's POV, `put`
-is just "remember this"; under the hood Atlas routes through quarantine →
-promotion → AGM revise() → Ripple cascade.
+Basic storage and lexical retrieval use Atlas's SQLite trust store and need no
+Neo4j or Docker.  Deployments that enable Neo4j can additionally use AGM
+revision, graph lineage, and Ripple reassessment through Atlas's MCP surface.
 
 INSTALL (Hermes side):
     # hermes_config.yaml
@@ -26,33 +28,24 @@ INSTALL (Hermes side):
         neo4j_password: atlasdev
         atlas_data_dir: ~/.atlas
 
-CONTRACT NOTES (W7 follow-ups):
+CONTRACT NOTES:
 1. Hermes MemoryItem fields we expect: id, content (str), metadata (dict),
    created_at (iso8601), embedding (optional list[float]).
-2. Atlas owns the canonical id (kref:// scheme); hermes_id ↔ kref map lives
-   in atlas_core/adapters/hermes_id_map.py (W7).
-3. `search` routes through atlas_core/retrieval (vault-search 768-dim BGE) +
-   Cypher kref hop expansion. Top-k is post-AGM-state, so superseded
-   revisions never surface unless explicitly requested via tag.
-4. `delete` becomes AGM contract() (Hansson Relevance + Core-Retainment),
-   not a tombstone — Atlas removes the belief from the closure rather than
-   from storage. The revision history stays auditable.
+2. Atlas owns the canonical candidate ID returned from `put`.
+3. `search` is deterministic local lexical retrieval over non-denied memory.
+4. `delete` removes the item from retrieval while preserving its audit row.
 
 Spec: 09 - Agent Runtime Memory Competitive Landscape.md (Hermes section)
 """
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from atlas_core.api.mcp_server import AtlasMCPServer
-
-
-log = logging.getLogger(__name__)
 
 
 PROVIDER_NAME: str = "atlas"
@@ -63,8 +56,7 @@ PROVIDER_NAME: str = "atlas"
 class HermesMemoryItem:
     """Mirrors hermes_agent.memory.MemoryItem shape.
 
-    Phase 2 W6 keeps this as a local dataclass to avoid importing Hermes;
-    W7 will switch to the upstream type once the plugin manifest is published.
+    Kept local so the adapter core has no Hermes installation dependency.
     """
 
     content: str
@@ -84,15 +76,33 @@ class HermesMemoryItem:
 
 
 class AtlasHermesProvider:
-    """Hermes MemoryProvider implementation backed by AtlasMCPServer.
+    """Hermes-shaped adapter core backed by AtlasMCPServer.
 
-    Hermes calls the four methods (put / search / get / delete) without
-    knowing they trigger AGM revision + Ripple cascade under the hood.
-    Errors surface as exceptions so Hermes' default error handler triggers.
+    The four operations use Atlas's portable SQLite memory tools. A caller
+    connected to a graph-enabled MCP server can separately invoke Atlas's AGM
+    and Ripple tools; ordinary CRUD does not pretend to trigger them.
     """
 
     def __init__(self, *, mcp_server: AtlasMCPServer):
         self.mcp = mcp_server
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None = None) -> AtlasHermesProvider:
+        """Construct the functional SQLite adapter without Neo4j or Docker."""
+        from pathlib import Path
+
+        from atlas_core.api import AtlasMCPServer
+        from atlas_core.trust import HashChainedLedger, QuarantineStore
+
+        config = config or {}
+        data_dir = Path(config.get("atlas_data_dir", str(Path.home() / ".atlas")))
+        data_dir = data_dir.expanduser()
+        data_dir.mkdir(parents=True, exist_ok=True)
+        return cls(mcp_server=AtlasMCPServer(
+            driver=None,
+            quarantine=QuarantineStore(data_dir / "candidates.db"),
+            ledger=HashChainedLedger(data_dir / "ledger.db"),
+        ))
 
     async def put(self, item: HermesMemoryItem) -> str:
         """Hermes wants to remember `item`. Atlas routes through quarantine.
@@ -102,7 +112,7 @@ class AtlasHermesProvider:
           - item.metadata['subject_kref'] → subject_kref (REQUIRED)
           - item.metadata['predicate']    → predicate (REQUIRED)
           - item.metadata['confidence']   → confidence (default 0.6)
-          - item.metadata['lane']         → lane (default 'atlas_curated')
+          - item.metadata['lane']         → lane (default 'atlas_chat_history')
           - item.created_at        → evidence_timestamp
         """
         meta = item.metadata
@@ -137,29 +147,40 @@ class AtlasHermesProvider:
     async def search(
         self, query: str, k: int = 10,
     ) -> list[HermesMemoryItem]:
-        """W7 wires this through atlas_core/retrieval (vault-search BGE +
-        Cypher kref expansion). Phase 2 W6 returns an empty list with a
-        clear log line so Hermes' fallback path is exercised in dev.
-        """
-        log.info(
-            "AtlasHermesProvider.search(%r, k=%d) — W7 wires retrieval; "
-            "returning [] for now.", query, k,
-        )
-        return []
+        """Return real SQLite-ranked Atlas memories."""
+        result = await self.mcp.dispatch("memory.search", {"query": query, "limit": k})
+        if not result.ok:
+            raise RuntimeError(f"Atlas search failed: {result.error}")
+        return [self._from_memory(row) for row in result.result["memories"]]
 
     async def get(self, item_id: str) -> HermesMemoryItem | None:
-        """item_id is a quarantine candidate_id ULID. W7 wires the lookup."""
-        log.info(
-            "AtlasHermesProvider.get(%r) — W7 wires candidate lookup; "
-            "returning None for now.", item_id,
-        )
-        return None
+        """Fetch one retrievable memory by Atlas candidate ID."""
+        result = await self.mcp.dispatch("memory.get", {"memory_id": item_id})
+        if not result.ok:
+            raise RuntimeError(f"Atlas get failed: {result.error}")
+        row = result.result["memory"]
+        return self._from_memory(row) if row else None
 
     async def delete(self, item_id: str) -> bool:
-        """W7 routes through AGM contract(). Phase 2 W6 returns False so
-        Hermes doesn't think the delete succeeded silently."""
-        log.info(
-            "AtlasHermesProvider.delete(%r) — W7 routes via AGM contract(); "
-            "returning False for now.", item_id,
+        """Remove one memory from retrieval while retaining its audit row."""
+        result = await self.mcp.dispatch("memory.forget", {"memory_id": item_id})
+        if not result.ok:
+            raise RuntimeError(f"Atlas delete failed: {result.error}")
+        return bool(result.result["forgotten"])
+
+    @staticmethod
+    def _from_memory(row: dict[str, Any]) -> HermesMemoryItem:
+        return HermesMemoryItem(
+            item_id=row["memory_id"],
+            content=row["text"],
+            created_at=row.get("created_at"),
+            metadata={
+                "score": row["score"],
+                "status": row["status"],
+                "lane": row["lane"],
+                "subject_kref": row["subject_kref"],
+                "predicate": row["predicate"],
+                "confidence": row["confidence"],
+                "trust_score": row["trust_score"],
+            },
         )
-        return False

--- a/atlas_core/adapters/openclaw.py
+++ b/atlas_core/adapters/openclaw.py
@@ -1,8 +1,11 @@
-"""OpenClaw memory plugin adapter — Atlas as a memory backend in
-OpenClaw's plugin architecture (363K stars, plugin manifest at
-github.com/OpenClawIO/openclaw/blob/main/docs/plugins/memory.md inferred).
+"""SDK-neutral OpenClaw adapter core backed by Atlas local memory tools.
 
-OpenClaw plugin contract (memory subtype):
+The Python protocol below was drafted against an earlier inferred OpenClaw
+contract. Current OpenClaw memory plugins are TypeScript packages built on the
+official plugin SDK and ``registerMemoryCapability``. This module is therefore
+a tested integration core, not a claim of current native plugin packaging.
+
+The adapter operations are real and need no Neo4j or Docker:
     plugin.json:
       {
         "name": "atlas-memory",
@@ -20,10 +23,10 @@ OpenClaw plugin contract (memory subtype):
 
     Recall = dataclass(memory_id, text, score, metadata, timestamp)
 
-OpenClaw is more conversational than Hermes — it expects raw text as
-the storage primitive. Atlas wraps that by auto-extracting subject_kref +
-predicate via LLM (W7), with a deterministic fallback that uses the agent
-session id as the subject and 'said' as the predicate.
+OpenClaw is more conversational than Hermes, so Atlas deterministically maps
+raw text to an agent/session subject and a configurable predicate. Storage,
+retrieval, listing, and forgetting run against the local SQLite trust store.
+Neo4j remains optional for Atlas's graph revision and Ripple features.
 
 Spec: 09 - Agent Runtime Memory Competitive Landscape.md (OpenClaw section)
       Plugin manifest: contract sketched here, validated against upstream W7.
@@ -31,16 +34,12 @@ Spec: 09 - Agent Runtime Memory Competitive Landscape.md (OpenClaw section)
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from atlas_core.api.mcp_server import AtlasMCPServer
-
-
-log = logging.getLogger(__name__)
 
 
 PLUGIN_NAME: str = "atlas-memory"
@@ -60,12 +59,11 @@ class Recall:
 
 
 class AtlasOpenClawPlugin:
-    """OpenClaw memory plugin backed by AtlasMCPServer.
+    """OpenClaw-shaped adapter core backed by AtlasMCPServer.
 
-    Differs from Hermes adapter in that OpenClaw passes raw text and expects
-    the plugin to handle structuring. We auto-derive subject + predicate
-    from session metadata + a default 'said' predicate; W7 swaps in LLM
-    extraction when an extractor is configured.
+    It accepts raw text and deterministically derives subject + predicate from
+    session metadata. Native current-OpenClaw packaging lives outside this
+    Python protocol.
     """
 
     def __init__(self, *, mcp_server: AtlasMCPServer):
@@ -110,83 +108,78 @@ class AtlasOpenClawPlugin:
         return result.result["candidate_id"]
 
     async def recall(self, query: str, k: int = 5) -> list[Recall]:
-        """W7 wires through retrieval layer (BGE + kref hop). Phase 2 W6
-        returns empty list — OpenClaw falls back to in-context memory."""
-        log.info(
-            "AtlasOpenClawPlugin.recall(%r, k=%d) — W7 wires retrieval; "
-            "returning [] for now.", query, k,
-        )
-        return []
+        """Return real SQLite-ranked Atlas memories."""
+        result = await self.mcp.dispatch("memory.search", {"query": query, "limit": k})
+        if not result.ok:
+            raise RuntimeError(f"Atlas recall failed: {result.error}")
+        return [self._from_memory(row) for row in result.result["memories"]]
 
     async def forget(self, memory_id: str) -> bool:
-        """W7 wires AGM contract(). Phase 2 W6 returns False so OpenClaw
-        knows the deletion didn't actually happen."""
-        log.info(
-            "AtlasOpenClawPlugin.forget(%r) — W7 wires AGM contract; "
-            "returning False for now.", memory_id,
-        )
-        return False
+        """Remove one memory from retrieval while retaining its audit row."""
+        result = await self.mcp.dispatch("memory.forget", {"memory_id": memory_id})
+        if not result.ok:
+            raise RuntimeError(f"Atlas forget failed: {result.error}")
+        return bool(result.result["forgotten"])
 
     async def list_memories(
         self, filter: dict[str, Any] | None = None,
     ) -> list[Recall]:
-        """List quarantine candidates by agent_id (filter['agent_id'])."""
-        result = await self.mcp.dispatch(
-            "quarantine.list_pending",
-            {"limit": (filter or {}).get("limit", 50)},
-        )
+        """List retrievable memories, optionally filtered by agent ID."""
+        result = await self.mcp.dispatch("memory.list", {
+            "limit": (filter or {}).get("limit", 50),
+            **({"lane": filter["lane"]} if filter and filter.get("lane") else {}),
+        })
         if not result.ok:
-            return []
+            raise RuntimeError(f"Atlas list failed: {result.error}")
         agent_id = (filter or {}).get("agent_id")
-        rows = result.result["candidates"]
+        rows = result.result["memories"]
         if agent_id:
             rows = [
                 r for r in rows
                 if f"openclaw/Agents/{agent_id}" in r["subject_kref"]
             ]
-        return [
-            Recall(
-                memory_id=r["candidate_id"],
-                text=r["object_value"],
-                score=float(r.get("trust_score", 0.0)),
-                metadata={
-                    "lane": r["lane"],
-                    "subject_kref": r["subject_kref"],
-                    "predicate": r["predicate"],
-                },
-                timestamp=r.get("created_at"),
-            )
-            for r in rows
-        ]
+        return [self._from_memory(row) for row in rows]
+
+    @staticmethod
+    def _from_memory(row: dict[str, Any]) -> Recall:
+        return Recall(
+            memory_id=row["memory_id"],
+            text=row["text"],
+            score=float(row["score"]),
+            metadata={
+                "status": row["status"],
+                "lane": row["lane"],
+                "subject_kref": row["subject_kref"],
+                "predicate": row["predicate"],
+                "confidence": row["confidence"],
+                "trust_score": row["trust_score"],
+            },
+            timestamp=row.get("created_at"),
+        )
 
 
 def plugin(config: dict[str, Any]) -> AtlasOpenClawPlugin:
-    """OpenClaw plugin entrypoint. `openclaw load atlas-memory` calls this.
+    """Construct the functional SQLite adapter core.
 
     config keys:
-      neo4j_uri / neo4j_user / neo4j_password — Neo4j connection
-      atlas_data_dir                          — for candidates.db + ledger.db
+      atlas_data_dir — for candidates.db + ledger.db
+
+    This factory does not claim to be OpenClaw's current TypeScript plugin SDK
+    entrypoint. It exists for Python hosts and contract-level testing.
     """
     from pathlib import Path
-
-    from neo4j import AsyncGraphDatabase
 
     from atlas_core.api import AtlasMCPServer
     from atlas_core.trust import HashChainedLedger, QuarantineStore
 
-    data_dir = Path(config.get("atlas_data_dir", str(Path.home() / ".atlas")))
+    data_dir = Path(
+        config.get("atlas_data_dir", str(Path.home() / ".atlas")),
+    ).expanduser()
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    driver = AsyncGraphDatabase.driver(
-        config.get("neo4j_uri", "bolt://localhost:7687"),
-        auth=(
-            config.get("neo4j_user", "neo4j"),
-            config.get("neo4j_password", "atlasdev"),
-        ),
-    )
     quarantine = QuarantineStore(data_dir / "candidates.db")
     ledger = HashChainedLedger(data_dir / "ledger.db")
     server = AtlasMCPServer(
-        driver=driver, quarantine=quarantine, ledger=ledger,
+        driver=None, quarantine=quarantine, ledger=ledger,
     )
     return AtlasOpenClawPlugin(mcp_server=server)

--- a/atlas_core/api/mcp_server.py
+++ b/atlas_core/api/mcp_server.py
@@ -63,7 +63,7 @@ class MCPToolResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-# ─── Tool inventory (Atlas-original 8) ───────────────────────────────────────
+# ─── Tool inventory ──────────────────────────────────────────────────────────
 
 
 ATLAS_MCP_TOOLS: tuple[str, ...] = (
@@ -74,6 +74,10 @@ ATLAS_MCP_TOOLS: tuple[str, ...] = (
     "adjudication.resolve",
     "quarantine.upsert",
     "quarantine.list_pending",
+    "memory.search",
+    "memory.get",
+    "memory.list",
+    "memory.forget",
     "ledger.verify_chain",
     "working_memory.assemble",
     "lineage.walk",
@@ -87,7 +91,7 @@ ATLAS_MCP_TOOLS: tuple[str, ...] = (
 
 
 class AtlasMCPServer:
-    """Atlas MCP server. Wires the 8 Atlas-original tools to their backends.
+    """Atlas MCP server. Wires Atlas's public tools to their backends.
 
     The server is transport-agnostic — `dispatch(tool_name, params)` is the
     single entry point. Production wiring (stdio for Claude Code plugin, HTTP
@@ -271,6 +275,63 @@ class AtlasMCPServer:
                 },
             },
             handler=self._tool_quarantine_list_pending,
+        ))
+
+        self.register(MCPTool(
+            name="memory.search",
+            description=(
+                "Search Atlas's local SQLite memory store with deterministic "
+                "lexical ranking. Works without Neo4j or Docker."
+            ),
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer", "default": 10, "minimum": 1},
+                    "lane": {"type": "string"},
+                },
+                "required": ["query"],
+            },
+            handler=self._tool_memory_search,
+        ))
+
+        self.register(MCPTool(
+            name="memory.get",
+            description="Fetch one Atlas memory by candidate ID. No graph required.",
+            parameters_schema={
+                "type": "object",
+                "properties": {"memory_id": {"type": "string"}},
+                "required": ["memory_id"],
+            },
+            handler=self._tool_memory_get,
+        ))
+
+        self.register(MCPTool(
+            name="memory.list",
+            description="List retrievable non-denied Atlas memories newest first.",
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "lane": {"type": "string"},
+                    "limit": {"type": "integer", "default": 50, "minimum": 1},
+                },
+            },
+            handler=self._tool_memory_list,
+        ))
+
+        self.register(MCPTool(
+            name="memory.forget",
+            description=(
+                "Remove a memory from the retrieval surface while preserving "
+                "its auditable quarantine record. This does not contract an "
+                "already-promoted graph belief or ledger event."
+            ),
+            parameters_schema={
+                "type": "object",
+                "properties": {"memory_id": {"type": "string"}},
+                "required": ["memory_id"],
+            },
+            handler=self._tool_memory_forget,
         ))
 
         self.register(MCPTool(
@@ -668,6 +729,60 @@ class AtlasMCPServer:
             ],
             "count": len(rows),
         }
+
+    @staticmethod
+    def _memory_row(row: dict[str, Any]) -> dict[str, Any]:
+        """Stable public shape shared by MCP and runtime adapters."""
+        return {
+            "memory_id": row["candidate_id"],
+            "text": row["object_value"],
+            "score": float(row.get("retrieval_score", row.get("trust_score", 0.0))),
+            "status": row["status"],
+            "lane": row["lane"],
+            "subject_kref": row["subject_kref"],
+            "predicate": row["predicate"],
+            "confidence": float(row["confidence"]),
+            "trust_score": float(row["trust_score"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    async def _tool_memory_search(
+        self,
+        query: str,
+        limit: int = 10,
+        lane: str | None = None,
+    ) -> dict[str, Any]:
+        rows = self.quarantine.search_memories(query, limit=limit, lane=lane)
+        memories = [self._memory_row(row) for row in rows]
+        return {"memories": memories, "count": len(memories), "backend": "sqlite"}
+
+    async def _tool_memory_get(self, memory_id: str) -> dict[str, Any]:
+        row = self.quarantine.get_candidate(memory_id)
+        if row is None or row["status"] == "denied":
+            return {"memory": None}
+        return {"memory": self._memory_row(row)}
+
+    async def _tool_memory_list(
+        self,
+        lane: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        rows = self.quarantine.list_memories(lane=lane, limit=limit)
+        memories = [self._memory_row(row) for row in rows]
+        return {"memories": memories, "count": len(memories), "backend": "sqlite"}
+
+    async def _tool_memory_forget(self, memory_id: str) -> dict[str, Any]:
+        row = self.quarantine.get_candidate(memory_id)
+        if row is None:
+            return {"forgotten": False, "memory_id": memory_id}
+        if row["status"] != "denied":
+            self.quarantine.deny_candidate(
+                memory_id,
+                reason="removed from adapter retrieval surface",
+                decision_id="memory.forget",
+            )
+        return {"forgotten": True, "memory_id": memory_id}
 
     async def _tool_ledger_verify_chain(self) -> dict[str, Any]:
         result = self.ledger.verify_chain()

--- a/atlas_core/trust/quarantine.py
+++ b/atlas_core/trust/quarantine.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -580,6 +581,109 @@ class QuarantineStore:
                 (CandidateStatus.APPROVED.value,),
             ).fetchall()
         return [dict(r) for r in rows]
+
+    def list_memories(
+        self,
+        *,
+        lane: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return retrievable, non-denied candidates newest first.
+
+        This is the portable adapter surface.  It intentionally reads the
+        SQLite trust store directly, so basic agent memory does not require
+        Neo4j.  Graph propagation remains an optional higher tier.
+        """
+        if limit < 1:
+            return []
+        sql = "SELECT * FROM candidates WHERE status != ?"
+        params: list[Any] = [CandidateStatus.DENIED.value]
+        if lane is not None:
+            sql += " AND lane = ?"
+            params.append(lane)
+        sql += " ORDER BY updated_at DESC LIMIT ?"
+        params.append(limit)
+        with self._connection() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    def search_memories(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        lane: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Rank non-denied candidates with deterministic lexical retrieval.
+
+        The scorer favors phrase matches in memory text, then token coverage
+        across text, predicate, and subject.  Confidence and trust break ties.
+        It is deliberately dependency-free and local; deployments can layer
+        embeddings or graph traversal on top without changing adapter APIs.
+        """
+        terms = tuple(dict.fromkeys(
+            token for token in re.findall(r"[a-z0-9_]+", query.lower())
+            if len(token) > 1
+        ))
+        if not terms or limit < 1:
+            return []
+
+        clauses: list[str] = []
+        params: list[Any] = [CandidateStatus.DENIED.value]
+        for term in terms:
+            clauses.append(
+                "(lower(object_value) LIKE ? OR lower(predicate) LIKE ? "
+                "OR lower(subject_kref) LIKE ?)"
+            )
+            like = f"%{term}%"
+            params.extend((like, like, like))
+        sql = (
+            "SELECT * FROM candidates WHERE status != ? AND ("
+            + " OR ".join(clauses)
+            + ")"
+        )
+        if lane is not None:
+            sql += " AND lane = ?"
+            params.append(lane)
+        sql += " ORDER BY updated_at DESC LIMIT ?"
+        params.append(max(1000, limit * 50))
+        with self._connection() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        candidates = [dict(row) for row in rows]
+        phrase = " ".join(terms)
+        ranked: list[tuple[float, str, dict[str, Any]]] = []
+        for candidate in candidates:
+            text = str(candidate["object_value"]).lower()
+            predicate = str(candidate["predicate"]).lower()
+            subject = str(candidate["subject_kref"]).lower()
+            combined = f"{text} {predicate} {subject}"
+            matched = sum(term in combined for term in terms)
+            if not matched:
+                continue
+
+            coverage = matched / len(terms)
+            text_coverage = sum(term in text for term in terms) / len(terms)
+            predicate_coverage = sum(term in predicate for term in terms) / len(terms)
+            subject_coverage = sum(term in subject for term in terms) / len(terms)
+            exact_phrase = 1.0 if phrase and phrase in text else 0.0
+            confidence = float(candidate.get("confidence", 0.0))
+            trust = float(candidate.get("trust_score", 0.0))
+            score = min(
+                1.0,
+                0.40 * coverage
+                + 0.25 * text_coverage
+                + 0.10 * predicate_coverage
+                + 0.05 * subject_coverage
+                + 0.10 * exact_phrase
+                + 0.05 * confidence
+                + 0.05 * trust,
+            )
+            item = dict(candidate)
+            item["retrieval_score"] = round(score, 6)
+            ranked.append((score, str(candidate["updated_at"]), item))
+
+        ranked.sort(key=lambda row: (row[0], row[1]), reverse=True)
+        return [row[2] for row in ranked[:limit]]
 
     def upsert_dead_letter(
         self,

--- a/docs/INSTALL_MODES.md
+++ b/docs/INSTALL_MODES.md
@@ -8,7 +8,7 @@ needs and skips the rest.
 |---|---|---|---|
 | **Researcher / dev** | You're reading the source, running benchmarks, contributing PRs | ~5 min | $0 |
 | **Obsidian power-user** | You have a vault and want Atlas watching it for contradictions | ~10 min | $0–$1/day in API calls if you turn on LLM extraction |
-| **Agent-runtime integration** | You're building on Hermes / OpenClaw / Claude Code and want a memory backend with belief revision | ~10 min | $0 |
+| **Agent-runtime integration** | You're building a Python/MCP integration; native latest-Hermes/OpenClaw packages remain planned | varies | $0 |
 
 Each section is self-contained — you should not need to read the others to
 get going.
@@ -26,13 +26,13 @@ git clone https://github.com/RichSchefren/atlas && cd atlas
 make setup        # creates .venv, installs -e .[dev], adds ruff
 make neo4j        # starts the Neo4j 5.26 container with APOC
 make doctor       # confirms 9/9 environment checks pass
-make test         # 518 tests, ~12 seconds
+make test         # 532 tests in this snapshot
 ```
 
 What you get:
 - All deterministic code paths (no LLM calls, no API keys required).
 - The full Ripple cascade, AGM operators, trust quarantine, hash-chained
-  ledger, and the 13 MCP tools.
+  ledger, and the 17 MCP tools.
 - The 49-scenario AGM compliance suite (`make bench-agm`).
 - The BusinessMemBench head-to-head matrix
   (`make bench-bmb` — runs the three measurable adapters; the five that
@@ -115,18 +115,21 @@ plain Python process, no system services to uninstall).
 ## Mode 3 — Agent-runtime integration
 
 You're building on Hermes, OpenClaw, Claude Code, or any MCP-speaking
-client, and you want Atlas as the memory backend that handles
-belief-revision under the hood.
+client. Start with the portable SQLite memory surface; add Neo4j only if
+you need Atlas's graph revision and Ripple behavior.
 
 ```bash
 git clone https://github.com/RichSchefren/atlas && cd atlas
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .         # core only — no LLM, no embeddings
-make neo4j
-make doctor
+PYTHONPATH=. python scripts/demo_runtime_adapters.py  # no Docker
 ```
 
-Pick the adapter for your runtime:
+That command proves Hermes-shaped and OpenClaw-shaped storage, retrieval,
+fetch/list, and forgetting. The current upstream-native packaging boundary is
+documented in [`RUNTIME_ADAPTERS.md`](RUNTIME_ADAPTERS.md).
+
+Pick the surface for your runtime:
 
 ### Claude Code (MCP, stdio)
 
@@ -152,58 +155,56 @@ Add Atlas to `~/.claude/.mcp.json` (the canonical Claude Code MCP config — see
 
 Restart Claude Code; Atlas's tools appear in the MCP tool list.
 
-Atlas exposes the 13 MCP tools (`ripple.analyze_impact`,
+Atlas exposes the 17 MCP tools (`ripple.analyze_impact`,
 `ripple.reassess`, `ripple.detect_contradictions`, `adjudication.queue`,
 `adjudication.resolve`, `quarantine.upsert`, `quarantine.list_pending`,
-`ledger.verify_chain`, `working_memory.assemble`, `lineage.walk`,
-`sharing.grant`, `sharing.revoke`, `sharing.list_grants`). Read-only vs
+`memory.search`, `memory.get`, `memory.list`, `memory.forget`,
+`ledger.verify_chain`, `working_memory.assemble`, `lineage.walk`, `sharing.grant`,
+`sharing.revoke`, `sharing.list_grants`). Read-only vs
 mutation classification is in [`docs/PROPOSAL_VS_MUTATION.md`](PROPOSAL_VS_MUTATION.md).
 
 ### Hermes
 
 ```python
-# In your Hermes agent config:
 from atlas_core.adapters.hermes import AtlasHermesProvider
 
-agent = Hermes(
-    memory_provider=AtlasHermesProvider(
-        neo4j_uri="bolt://localhost:7687",
-        neo4j_user="neo4j",
-        neo4j_password="atlasdev",
-    ),
-    ...
-)
+memory = AtlasHermesProvider.from_config({"atlas_data_dir": "~/.atlas"})
+memory_id = await memory.put(item)
+hits = await memory.search("pricing decision", k=5)
 ```
 
-Atlas registers as the 9th MemoryProvider in the Hermes ecosystem and is
-the only one that ships AGM-compliant revision.
+This is a functional Python adapter core, not a native current-Hermes plugin.
+Hermes Agent now requires a subclass of its lifecycle-based `MemoryProvider`
+with `initialize`, `prefetch`, `sync_turn`, tool dispatch, and shutdown hooks.
+Atlas will not claim native Hermes installation until that wrapper passes an
+actual Hermes-process round trip.
 
 ### OpenClaw
 
 ```python
-# Programmatic install — point your OpenClaw runtime at the plugin factory:
+# Python-hosted use of the SDK-neutral core:
 from atlas_core.adapters.openclaw import plugin as atlas_plugin
 
-atlas = atlas_plugin({
-    "neo4j_uri": "bolt://localhost:7687",
-    "neo4j_user": "neo4j",
-    "neo4j_password": "atlasdev",
-})  # returns AtlasOpenClawPlugin
+atlas = atlas_plugin({"atlas_data_dir": "~/.atlas"})
+memory_id = await atlas.store("Customer prefers weekly summaries", metadata)
+hits = await atlas.recall("reporting preference", k=5)
 ```
 
-Or, if your OpenClaw build supports declarative manifests:
+The factory returns `AtlasOpenClawPlugin`, the SDK-neutral Python core.
+Current OpenClaw cannot load this Python factory as a native memory plugin. It
+expects a TypeScript package using its plugin SDK and
+`registerMemoryCapability`. The core operations above are real; the npm
+wrapper remains planned and must pass inside an actual OpenClaw process before
+Atlas calls it drop-in.
 
-```yaml
-plugins:
-  - name: atlas-memory
-    type: memory
-    module: atlas_core.adapters.openclaw
-    factory: plugin
-```
+What you get without Neo4j:
+- SQLite-backed storage, deterministic lexical retrieval, fetch/list, and
+  auditable forgetting.
+- Four portable tools: `memory.search`, `memory.get`, `memory.list`, and
+  `memory.forget`.
 
-What you get:
-- The full Ripple cascade behind whatever interface your runtime
-  expects.
+What Neo4j adds:
+- The full Ripple cascade and AGM graph revision.
 - Read-only tools (analyze_impact, reassess, detect_contradictions,
   list_pending, verify_chain, assemble, lineage_walk, list_grants) that
   your agent can call freely without confirm-gating.
@@ -225,8 +226,8 @@ What you skip:
 ## Switching modes
 
 The modes are not exclusive. Researcher → Obsidian: just `pip install
-.[llm]` and set the env vars. Obsidian → Agent-runtime: install the
-adapter and point your runtime at the same Neo4j instance. The data dir
+.[llm]` and set the env vars. Obsidian → Agent-runtime: use the portable
+SQLite tools first, then point graph-capable clients at the same Neo4j instance. The data dir
 (`~/.atlas/`) and the Neo4j namespace are shared across modes by default,
 so you can run the synthetic demo, then start watching your vault, then
 plug Claude Code in — all against the same belief graph.

--- a/docs/LAUNCH_BACKLOG.md
+++ b/docs/LAUNCH_BACKLOG.md
@@ -108,7 +108,7 @@ The propagation-aware belief-revision loop is the jewel.
 - [x] **Proposal-vs-mutation explicit in API surface.**
       `docs/PROPOSAL_VS_MUTATION.md` classifies every public method in
       `atlas_core/ripple/`, `atlas_core/revision/`, `atlas_core/trust/`,
-      and the 13 MCP tools in `atlas_core/api/mcp_server.py` into
+      and the 17 MCP tools in `atlas_core/api/mcp_server.py` into
       READ-ONLY / PROPOSAL / MUTATION buckets. The invariant — *no
       typed-graph mutation happens automatically as part of Ripple
       propagation* — is enforced by an AST-based regression test

--- a/docs/PROPOSAL_VS_MUTATION.md
+++ b/docs/PROPOSAL_VS_MUTATION.md
@@ -98,7 +98,7 @@ stays sharp.
 
 ### `atlas_core/api/mcp_server.py` — the public MCP tool surface
 
-The 13 tools registered in `_register_atlas_tools()`, classified:
+The 17 tools registered in `_register_atlas_tools()`, classified:
 
 | MCP tool name | Class | Notes |
 |---|---|---|
@@ -109,6 +109,10 @@ The 13 tools registered in `_register_atlas_tools()`, classified:
 | `adjudication.resolve` | **MUTATION** | The *one* MCP tool that mutates the graph. Calls `resolve_adjudication()` → `revise()` / `contract()` + ledger append. **Requires a `proposal_id` that already exists in the queue + an explicit `decision` arg.** |
 | `quarantine.upsert` | **MUTATION (non-graph)** | Wraps `QuarantineStore.upsert_candidate()`. SQLite write only. |
 | `quarantine.list_pending` | **READ-ONLY** | SQLite read. |
+| `memory.search` | **READ-ONLY** | Deterministic lexical retrieval over non-denied SQLite candidates. |
+| `memory.get` | **READ-ONLY** | Fetches one non-denied SQLite candidate. |
+| `memory.list` | **READ-ONLY** | Lists non-denied SQLite candidates. |
+| `memory.forget` | **MUTATION (non-graph)** | Marks the candidate denied so retrieval excludes it; preserves the audit row. |
 | `ledger.verify_chain` | **READ-ONLY** | SQLite read + hash check. |
 | `working_memory.assemble` | **READ-ONLY** | Loads working-memory blocks; no writes. |
 | `lineage.walk` | **READ-ONLY** | Cypher MATCH traversal. |
@@ -123,11 +127,13 @@ The 13 tools registered in `_register_atlas_tools()`, classified:
 **For agent-runtime integrators (Hermes, OpenClaw, Claude Code):**
 You can wire `ripple.analyze_impact`, `ripple.reassess`,
 `ripple.detect_contradictions`, `adjudication.queue`,
-`quarantine.list_pending`, `ledger.verify_chain`, `working_memory.assemble`,
-`lineage.walk`, and `sharing.list_grants` as *read-only tools*. Your
+`quarantine.list_pending`, `memory.search`, `memory.get`, `memory.list`,
+`ledger.verify_chain`, `working_memory.assemble`, `lineage.walk`, and
+`sharing.list_grants` as *read-only tools*. Your
 agent can call them as often as it wants in a single turn; nothing in
 Atlas's state changes. Only `adjudication.resolve`, `quarantine.upsert`,
-and the two `sharing.{grant,revoke}` calls require user-confirm gating.
+`memory.forget`, and the two `sharing.{grant,revoke}` calls require
+user-confirm gating.
 
 **For Ripple-cascade callers:**
 `RippleEngine.propagate()` is safe to invoke speculatively. It returns

--- a/docs/RUNTIME_ADAPTERS.md
+++ b/docs/RUNTIME_ADAPTERS.md
@@ -1,0 +1,100 @@
+# Hermes and OpenClaw integration: what is real today
+
+Atlas previously overstated these integrations. The Python modules exposed
+`put` / `store`, but their retrieval and deletion methods returned empty or
+false values. They were adapter-shaped stubs, and the README called them
+drop-in plugins even though both upstream plugin contracts had changed.
+
+That is no longer the implementation state.
+
+## Runnable proof without Neo4j or Docker
+
+From the Atlas repository:
+
+```bash
+pip install -e .
+PYTHONPATH=. python scripts/demo_runtime_adapters.py
+```
+
+The script creates an isolated SQLite trust store and proves:
+
+- Hermes-shaped `put` -> `search` -> `get` -> `delete`;
+- OpenClaw-shaped `store` -> `recall` -> `list_memories` -> `forget`;
+- forgotten memories disappear from retrieval but remain auditable;
+- no Neo4j connection or Docker process is started.
+
+CI runs the same proof in
+`tests/integration/test_runtime_adapter_demo.py` with `NEO4J_URI` deliberately
+pointed at a dead port.
+
+## The two capability tiers
+
+### Portable memory tier — SQLite only
+
+The portable tier is usable by Python hosts and integration wrappers today:
+
+- trust-aware local storage;
+- deterministic lexical retrieval;
+- fetch and list operations;
+- auditable forgetting;
+- no API key, embedding model, Neo4j, or Docker requirement.
+
+Portable `forget` is retrieval suppression, not AGM contraction. If a memory
+has already been promoted into the canonical ledger and Neo4j graph, use the
+graph adjudication/revision path to change that canonical state as well.
+
+The shared MCP/HTTP surface exposes `memory.search`, `memory.get`,
+`memory.list`, and `memory.forget`. Both adapter cores call those same tools,
+so their behavior is not duplicated or mocked.
+
+### Cognitive graph tier — Neo4j
+
+Neo4j is required for the feature that makes Atlas different from ordinary
+memory backends:
+
+- typed belief and decision graphs;
+- AGM revision and contraction;
+- dependency and lineage walks;
+- Ripple downstream reassessment;
+- graph-aware contradiction detection.
+
+Docker is the documented local setup, not the only possible deployment.
+Neo4j Desktop, a native Neo4j service, or Aura can provide the same Bolt
+endpoint.
+
+## Upstream compatibility boundary
+
+The modules `atlas_core.adapters.hermes` and
+`atlas_core.adapters.openclaw` are functional SDK-neutral adapter cores. They
+are not currently installable native plugins for the latest upstream runtimes.
+
+Current Hermes Agent expects a Python plugin that subclasses
+`agent.memory_provider.MemoryProvider` and implements lifecycle hooks including
+`initialize`, `prefetch`, `sync_turn`, tool schemas, tool dispatch, and
+`shutdown` ([upstream contract](https://github.com/NousResearch/hermes-agent/blob/main/agent/memory_provider.py)). Atlas's older four-method class is the working persistence and
+retrieval core a native wrapper can call, but it is not that wrapper.
+
+Current OpenClaw expects a TypeScript package built on its plugin SDK, with a
+memory manifest and `registerMemoryCapability`. A Python `plugin(config)`
+factory cannot be loaded directly by current OpenClaw. Atlas's Python class is
+the tested storage/retrieval core, not the final npm package. See OpenClaw's
+[plugin SDK overview](https://docs.openclaw.ai/plugins/sdk-overview).
+
+Until those native packages are built and tested inside the actual upstream
+processes, Atlas will not label them drop-in integrations. Native packaging is
+tracked in [#27 for Hermes](https://github.com/RichSchefren/atlas/issues/27)
+and [#26 for OpenClaw](https://github.com/RichSchefren/atlas/issues/26).
+
+## Integration choices today
+
+1. Python runtimes can construct `AtlasHermesProvider.from_config(...)` or
+   `AtlasOpenClawPlugin` and use the portable operations directly.
+2. Any runtime can call the four `memory.*` tools through Atlas MCP or HTTP.
+3. Hermes and OpenClaw plugin authors can wrap the portable surface without
+   requiring the Neo4j tier.
+4. Teams that want Ripple and AGM behavior can point the same Atlas instance
+   at Neo4j; the adapter-facing memory calls do not change.
+
+The acceptance standard for future native packages is a real upstream-process
+round trip: capture a turn, retrieve it in a later turn, fetch it by ID, forget
+it, and prove it no longer appears—all in both Hermes Agent and OpenClaw CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,12 +105,10 @@ dev = [
     "anthropic>=0.49.0",
 ]
 
-# pip install atlas-core[adapters]
-#   Hermes / OpenClaw integration deps installed only when wiring
-#   Atlas as a memory backend in those upstream runtimes.
+# The SDK-neutral Hermes/OpenClaw cores need no extra dependencies.
+# Native current-upstream wrappers are not yet distributed from this repo.
 adapters = [
-    # Reserved — Hermes-agent and OpenClaw clients ship their own
-    # SDKs; we don't pin them here to avoid version drift.
+    # Reserved for future version-pinned native wrapper packages.
 ]
 
 [project.urls]

--- a/scripts/demo_runtime_adapters.py
+++ b/scripts/demo_runtime_adapters.py
@@ -1,0 +1,72 @@
+"""Prove Hermes/OpenClaw adapter CRUD + retrieval without Neo4j or Docker.
+
+Run from the repository root:
+
+    PYTHONPATH=. python scripts/demo_runtime_adapters.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from atlas_core.adapters import (
+    AtlasHermesProvider,
+    AtlasOpenClawPlugin,
+    HermesMemoryItem,
+)
+from atlas_core.api import AtlasMCPServer
+from atlas_core.trust import HashChainedLedger, QuarantineStore
+
+
+async def run_demo() -> None:
+    with tempfile.TemporaryDirectory(prefix="atlas-adapters-") as tmp:
+        data_dir = Path(tmp)
+        server = AtlasMCPServer(
+            driver=None,
+            quarantine=QuarantineStore(data_dir / "candidates.db"),
+            ledger=HashChainedLedger(data_dir / "ledger.db"),
+        )
+        hermes = AtlasHermesProvider(mcp_server=server)
+        openclaw = AtlasOpenClawPlugin(mcp_server=server)
+
+        hermes_id = await hermes.put(HermesMemoryItem(
+            content="The Atlas launch webinar is Thursday at 2 PM",
+            metadata={
+                "subject_kref": "kref://Atlas/Events/launch.event",
+                "predicate": "schedule.start",
+                "confidence": 0.85,
+                "lane": "atlas_chat_history",
+            },
+        ))
+        openclaw_id = await openclaw.store(
+            "Richard prefers concise weekly status reports",
+            metadata={
+                "agent_id": "chief_of_staff",
+                "session_id": "demo",
+                "predicate": "pref.reporting_style",
+                "confidence": 0.85,
+            },
+        )
+
+        hermes_hits = await hermes.search("Atlas webinar Thursday", k=3)
+        openclaw_hits = await openclaw.recall("concise status reports", k=3)
+        fetched = await hermes.get(hermes_id)
+        forgotten = await openclaw.forget(openclaw_id)
+        after_forget = await openclaw.recall("concise status reports", k=3)
+
+        assert [hit.item_id for hit in hermes_hits] == [hermes_id]
+        assert [hit.memory_id for hit in openclaw_hits] == [openclaw_id]
+        assert fetched is not None and fetched.content.endswith("2 PM")
+        assert forgotten is True and after_forget == []
+
+        print("Atlas portable runtime-adapter proof")
+        print("  backend: SQLite only (Neo4j/Docker not started)")
+        print(f"  Hermes:   put={hermes_id} search=1 get=ok")
+        print(f"  OpenClaw: store={openclaw_id} recall=1 forget=ok")
+        print("  result: PASS — storage and retrieval are functional, not stubs")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_demo())

--- a/tests/integration/test_adapters.py
+++ b/tests/integration/test_adapters.py
@@ -75,13 +75,13 @@ class TestClaudeCodeAdapter:
         assert response["result"]["protocolVersion"] == PROTOCOL_VERSION
         assert response["result"]["serverInfo"]["name"] == "atlas"
 
-    async def test_tools_list_returns_eight(self, mcp_server):
+    async def test_tools_list_returns_seventeen(self, mcp_server):
         from atlas_core.adapters.claude_code import _handle
 
         response = await _handle(mcp_server, {
             "jsonrpc": "2.0", "id": 2, "method": "tools/list",
         })
-        assert len(response["result"]["tools"]) == 13
+        assert len(response["result"]["tools"]) == 17
 
     async def test_tools_call_dispatches(self, mcp_server):
         from atlas_core.adapters.claude_code import _handle
@@ -142,17 +142,29 @@ class TestHermesAdapter:
         with pytest.raises(ValueError, match="subject_kref"):
             await provider.put(HermesMemoryItem(content="x", metadata={}))
 
-    async def test_search_stub_returns_empty(self, mcp_server):
-        from atlas_core.adapters import AtlasHermesProvider
+    async def test_search_get_delete_round_trip(self, mcp_server):
+        from atlas_core.adapters import AtlasHermesProvider, HermesMemoryItem
 
         provider = AtlasHermesProvider(mcp_server=mcp_server)
-        assert await provider.search("anything", k=5) == []
+        memory_id = await provider.put(HermesMemoryItem(
+            content="The launch webinar is scheduled for Thursday",
+            metadata={
+                "subject_kref": "kref://test/Events/launch.event",
+                "predicate": "schedule.date",
+                "confidence": 0.7,
+                "lane": "atlas_chat_history",
+            },
+        ))
 
-    async def test_delete_stub_returns_false(self, mcp_server):
-        from atlas_core.adapters import AtlasHermesProvider
-
-        provider = AtlasHermesProvider(mcp_server=mcp_server)
-        assert await provider.delete("any-id") is False
+        hits = await provider.search("launch webinar Thursday", k=5)
+        assert [hit.item_id for hit in hits] == [memory_id]
+        assert hits[0].content == "The launch webinar is scheduled for Thursday"
+        fetched = await provider.get(memory_id)
+        assert fetched is not None and fetched.item_id == memory_id
+        assert await provider.delete(memory_id) is True
+        assert await provider.get(memory_id) is None
+        assert await provider.search("launch webinar Thursday", k=5) == []
+        assert await provider.delete("missing-id") is False
 
 
 # ─── OpenClaw memory plugin ─────────────────────────────────────────────────
@@ -197,19 +209,35 @@ class TestOpenClawAdapter:
         for m in agent_alpha:
             assert "agent_alpha" in m.metadata["subject_kref"]
 
-    async def test_plugin_factory_constructs_plugin(self, tmp_dir, neo4j_uri, neo4j_auth):
+    async def test_recall_and_forget_round_trip(self, mcp_server):
+        from atlas_core.adapters import AtlasOpenClawPlugin
+
+        plugin = AtlasOpenClawPlugin(mcp_server=mcp_server)
+        memory_id = await plugin.store(
+            "Customer prefers concise weekly reports",
+            metadata={
+                "agent_id": "chief_of_staff",
+                "session_id": "sess_recall",
+                "predicate": "pref.reporting_style",
+                "confidence": 0.8,
+            },
+        )
+
+        hits = await plugin.recall("concise weekly reports", k=5)
+        assert [hit.memory_id for hit in hits] == [memory_id]
+        assert hits[0].text == "Customer prefers concise weekly reports"
+        assert await plugin.forget(memory_id) is True
+        assert await plugin.recall("concise weekly reports", k=5) == []
+        assert await plugin.forget("missing-id") is False
+
+    async def test_plugin_factory_needs_no_neo4j(self, tmp_dir):
         from atlas_core.adapters import openclaw_plugin
 
-        user, password = neo4j_auth
         plug = openclaw_plugin({
-            "neo4j_uri": neo4j_uri,
-            "neo4j_user": user,
-            "neo4j_password": password,
             "atlas_data_dir": str(tmp_dir),
         })
         assert plug is not None
-        # Cleanup driver opened by factory
-        await plug.mcp.driver.close()
+        assert plug.mcp.driver is None
 
     async def test_plugin_metadata_constants(self):
         from atlas_core.adapters import (

--- a/tests/integration/test_claude_code_stdio.py
+++ b/tests/integration/test_claude_code_stdio.py
@@ -4,7 +4,7 @@ Forks a subprocess running `python -m atlas_core.adapters.claude_code`
 and exchanges actual JSON-RPC 2.0 frames over stdin/stdout. Asserts:
 
   - initialize handshake returns protocol version + serverInfo
-  - tools/list returns all 13 Atlas tools
+  - tools/list returns all 17 Atlas tools
   - tools/call dispatches a real tool (ledger.verify_chain) and the
     response chain is intact
   - tools/call on an unknown tool surfaces isError=True
@@ -92,7 +92,7 @@ class TestStdioWireProtocol:
         assert response["result"]["protocolVersion"]
         assert response["result"]["serverInfo"]["name"] == "atlas"
 
-    def test_tools_list_returns_eight(self, stdio_server):
+    def test_tools_list_returns_seventeen(self, stdio_server):
         # Initialize first per MCP spec
         send(stdio_server, {
             "jsonrpc": "2.0", "id": 1, "method": "initialize",
@@ -105,7 +105,7 @@ class TestStdioWireProtocol:
         })
         assert response is not None
         tools = response["result"]["tools"]
-        assert len(tools) == 13
+        assert len(tools) == 17
         names = {t["name"] for t in tools}
         # Spot check the headline tools
         assert "ripple.analyze_impact" in names

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -82,7 +82,7 @@ class TestHTTPTools:
         response = await client.get("/tools")
         assert response.status_code == 200
         tools = response.json()["tools"]
-        assert len(tools) == 13
+        assert len(tools) == 17
         names = {t["name"] for t in tools}
         assert names == set(ATLAS_MCP_TOOLS)
 

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -1,6 +1,6 @@
 """Integration tests for Atlas MCP server — uses live Neo4j.
 
-Verifies the 8 Atlas-original tools dispatch correctly and produce the
+Verifies Atlas's public tools dispatch correctly and produce the
 expected result shapes.
 """
 
@@ -85,13 +85,13 @@ async def cleanup_neo4j(driver, ns):
 
 
 class TestServerRegistration:
-    def test_eight_tools_registered(self, mcp_server):
+    def test_seventeen_tools_registered(self, mcp_server):
         from atlas_core.api import ATLAS_MCP_TOOLS
 
         listed = mcp_server.list_tools()
         names = {t["name"] for t in listed}
         assert names == set(ATLAS_MCP_TOOLS)
-        assert len(listed) == 13
+        assert len(listed) == 17
 
     def test_tool_definitions_have_input_schema(self, mcp_server):
         for tool in mcp_server.list_tools():
@@ -223,6 +223,47 @@ class TestQuarantineTools:
         assert result.ok is True
         assert result.result["is_auto_promoted"] is True
         assert result.result["trust_score"] == 1.0
+
+
+# ─── portable memory tools (SQLite only) ───────────────────────────────────
+
+
+class TestMemoryTools:
+    async def test_search_get_list_forget_round_trip(self, mcp_server):
+        upsert = await mcp_server.dispatch("quarantine.upsert", {
+            "lane": "atlas_chat_history",
+            "assertion_type": "preference",
+            "subject_kref": "kref://test/People/rich.person",
+            "predicate": "pref.reporting_style",
+            "object_value": "concise weekly reports",
+            "confidence": 0.75,
+            "evidence_source": "adapter_test",
+            "evidence_source_family": "agent",
+            "evidence_kref": "kref://test/Sessions/adapter.session",
+            "evidence_timestamp": "2026-07-16T00:00:00+00:00",
+        })
+        assert upsert.ok is True
+        memory_id = upsert.result["candidate_id"]
+
+        search = await mcp_server.dispatch(
+            "memory.search", {"query": "concise weekly reports", "limit": 5},
+        )
+        assert search.ok is True and search.result["backend"] == "sqlite"
+        assert [row["memory_id"] for row in search.result["memories"]] == [memory_id]
+
+        fetched = await mcp_server.dispatch("memory.get", {"memory_id": memory_id})
+        assert fetched.ok is True
+        assert fetched.result["memory"]["text"] == "concise weekly reports"
+
+        listed = await mcp_server.dispatch("memory.list", {"limit": 10})
+        assert memory_id in {row["memory_id"] for row in listed.result["memories"]}
+
+        forgotten = await mcp_server.dispatch("memory.forget", {"memory_id": memory_id})
+        assert forgotten.ok is True and forgotten.result["forgotten"] is True
+        after = await mcp_server.dispatch(
+            "memory.search", {"query": "concise weekly reports", "limit": 5},
+        )
+        assert after.result["memories"] == []
 
 
 # ─── ledger.verify_chain ────────────────────────────────────────────────────

--- a/tests/integration/test_runtime_adapter_demo.py
+++ b/tests/integration/test_runtime_adapter_demo.py
@@ -1,0 +1,32 @@
+"""Public no-Docker adapter proof must stay runnable."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_runtime_adapter_demo_passes_without_neo4j():
+    root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root)
+    # Deliberately poison the graph endpoint: the portable proof must not use it.
+    env["NEO4J_URI"] = "bolt://127.0.0.1:1"
+    result = subprocess.run(
+        [sys.executable, "scripts/demo_runtime_adapters.py"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Neo4j/Docker not started" in result.stdout
+    assert "result: PASS" in result.stdout

--- a/tests/unit/test_quarantine.py
+++ b/tests/unit/test_quarantine.py
@@ -281,6 +281,62 @@ class TestLifecycle:
         assert result1.candidate_id in ids
         assert result2.candidate_id not in ids
 
+    def test_list_memories_includes_all_non_denied_statuses(self, store):
+        pending = store.upsert_candidate(make_claim(
+            predicate="project.status", object_value="Atlas is active", confidence=0.5,
+        ))
+        denied = store.upsert_candidate(make_claim(
+            predicate="project.owner", object_value="Nobody", confidence=0.5,
+        ))
+        store.deny_candidate(denied.candidate_id, reason="wrong", decision_id="test")
+
+        ids = {row["candidate_id"] for row in store.list_memories()}
+        assert pending.candidate_id in ids
+        assert denied.candidate_id not in ids
+
+    def test_search_memories_ranks_phrase_and_hides_denied(self, store):
+        exact = store.upsert_candidate(make_claim(
+            predicate="schedule.launch",
+            object_value="Launch webinar happens Thursday morning",
+            confidence=0.8,
+        ))
+        partial = store.upsert_candidate(make_claim(
+            predicate="schedule.review",
+            object_value="Webinar review happens Friday",
+            confidence=0.8,
+        ))
+
+        hits = store.search_memories("launch webinar Thursday", limit=5)
+        assert [row["candidate_id"] for row in hits] == [exact.candidate_id, partial.candidate_id]
+        assert hits[0]["retrieval_score"] > hits[1]["retrieval_score"]
+
+        store.deny_candidate(exact.candidate_id, reason="forget", decision_id="test")
+        assert [row["candidate_id"] for row in store.search_memories(
+            "launch webinar Thursday", limit=5,
+        )] == [partial.candidate_id]
+
+    def test_search_memories_supports_lane_filter(self, store):
+        session = store.upsert_candidate(make_claim(
+            lane="atlas_sessions",
+            predicate="pref.format",
+            object_value="concise weekly reports",
+            confidence=0.8,
+        ))
+        chat = store.upsert_candidate(make_claim(
+            lane="atlas_chat_history",
+            predicate="pref.format",
+            object_value="concise weekly reports with charts",
+            confidence=0.8,
+            source="chat_1",
+            source_family="chat",
+        ))
+
+        hits = store.search_memories(
+            "concise weekly reports", lane="atlas_sessions", limit=5,
+        )
+        assert [row["candidate_id"] for row in hits] == [session.candidate_id]
+        assert chat.candidate_id not in {row["candidate_id"] for row in hits}
+
 
 # ─── Dead letter queue ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

External evaluation correctly found that Atlas's Hermes and OpenClaw adapters could write but returned empty/false for retrieval and deletion, while the README described them as complete drop-in plugins.

This PR fixes the product defect and the credibility defect separately.

## Product change

- add `QuarantineStore.list_memories()` and deterministic `search_memories()`
- add portable MCP/HTTP tools: `memory.search`, `memory.get`, `memory.list`, `memory.forget`
- make Hermes-shaped `put/search/get/delete` functional
- make OpenClaw-shaped `store/recall/list_memories/forget` functional
- make both portable cores run on SQLite without Neo4j, Docker, embeddings, or API keys
- preserve forgotten rows for audit; document that canonical graph/ledger contraction remains a separate AGM operation

## Public proof

```bash
PYTHONPATH=. python scripts/demo_runtime_adapters.py
```

The CI test deliberately points `NEO4J_URI` at a dead port and proves both round trips.

## Honest upstream boundary

Current Hermes Agent uses a lifecycle-based `MemoryProvider`; current OpenClaw uses a TypeScript plugin SDK and `registerMemoryCapability`. The previous Python modules are now accurately labeled functional SDK-neutral cores, not latest-upstream native packages.

Native packaging is tracked separately:
- OpenClaw: #26
- Hermes: #27

## Verification

- focused adapter/docs/MCP suite: 74 passed
- full suite: 532 passed
- Ruff: all checks passed
- Atlas doctor: all checks passed, 532 collected
- AGM compliance: 49/49
- BusinessMemBench Atlas adapter: 149/149
- portable demo: PASS with no Neo4j connection

Optional keyed BusinessMemBench competitors remain skipped because their credentials/SDKs are not configured; unrelated to this change.
