### PR TITLE
docs: publish native Hermes and OpenClaw packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,20 @@ PYTHONPATH=. python scripts/demo_runtime_adapters.py
 ```
 
 CI runs that proof with the Neo4j endpoint deliberately pointed at a dead port.
-The remaining boundary is packaging: current Hermes Agent uses its newer
-`MemoryProvider` lifecycle, and current OpenClaw uses a TypeScript plugin SDK.
-The Python modules in `atlas_core/adapters/` are functional SDK-neutral cores,
-not yet installable native packages for those latest upstream runtimes. The
-exact capability split and acceptance test are documented in
+Atlas also ships native packages for current Hermes Agent and OpenClaw:
+[`integrations/hermes-atlas/`](integrations/hermes-atlas/) implements Hermes's
+`MemoryProvider` lifecycle, and
+[`integrations/openclaw-atlas/`](integrations/openclaw-atlas/) is a TypeScript
+memory-capability plugin. Both are tested inside pinned upstream hosts, use
+SQLite directly, and work without Neo4j or Docker. The exact capability split
+and installation paths are documented in
 [`docs/RUNTIME_ADAPTERS.md`](docs/RUNTIME_ADAPTERS.md).
 
 ### Who Atlas is for, today
 
 The strongest early users are:
 
-- **Agent / tool builders** who need a memory backend with belief-revision semantics (MCP/HTTP surfaces plus tested Hermes/OpenClaw adapter cores ship today).
+- **Agent / tool builders** who need a memory backend with belief-revision semantics (MCP/HTTP surfaces plus native Hermes/OpenClaw packages ship today).
 - **Power users with Obsidian / transcripts / vaults** who want their meetings + screen + chat captures cross-checked for emergent contradictions.
 - **Local-first AI builders** who can't or won't ship user data to a cloud memory service.
 - **Researchers** working on belief revision, AGM compliance, or non-monotonic reasoning who want a reproducible, instrumented baseline.
@@ -358,9 +360,11 @@ Plus runtime adapters:
 - `atlas_core.adapters.claude_code` — MCP stdio bridge for Claude Code
 - `atlas_core.adapters.hermes.AtlasHermesProvider` — functional SQLite-backed Hermes-shaped core
 - `atlas_core.adapters.openclaw.AtlasOpenClawPlugin` — functional SQLite-backed OpenClaw-shaped core
+- `integrations/hermes-atlas/` — native current-Hermes `MemoryProvider` plugin
+- `integrations/openclaw-atlas/` — native current-OpenClaw TypeScript memory plugin
 
-The latter two are not labeled current upstream-native packages; see
-[`docs/RUNTIME_ADAPTERS.md`](docs/RUNTIME_ADAPTERS.md).
+See [`docs/RUNTIME_ADAPTERS.md`](docs/RUNTIME_ADAPTERS.md) for the portable
+core/native package boundary and proof matrix.
 
 ---
 
@@ -469,7 +473,6 @@ If you want to break Atlas, [TESTING.md](TESTING.md) has five concrete paths fro
 | LoCoMo + LongMemEval **measured** numbers (not asserted) | Datasets are research-license; haven't been downloaded + run yet. Runners exist (`benchmarks/locomo/`, `benchmarks/longmemeval/`); just need someone with dataset access to fire them. |
 | Mem0 / Letta / Memori columns in BMB matrix | Adapters fail-loud without `OPENAI_API_KEY` / `MEMORI_API_KEY`. Set the keys + re-run `scripts/run_bmb.py` to fill the rows. |
 | 1,000-question BusinessMemBench (currently 149 deterministic) | The 200 human-authored gold subset (templates in `benchmarks/business_mem_bench/gold_human/`) needs domain-operator authors. The remaining 800 are LLM-expanded from templates — runner ready, expansion not yet executed. |
-| Native latest-Hermes and latest-OpenClaw packages | Portable core is complete and tested; Hermes still needs a current `MemoryProvider` lifecycle wrapper ([#27](https://github.com/RichSchefren/atlas/issues/27)), and OpenClaw needs a TypeScript `registerMemoryCapability` package ([#26](https://github.com/RichSchefren/atlas/issues/26)). Neither will be called drop-in before a real upstream-process round trip passes. |
 | arxiv submission live | Tarball ready at `paper/arxiv/atlas-arxiv.tar.gz`. Submission goes through arxiv.org/submit (24-48h moderation). |
 | Confidence-threshold empirical calibration | Script exists at `scripts/calibrate_confidence_thresholds.py`. Needs a week of real ingest data before it produces a meaningful recommendation. |
 | Obsidian plugin in the Community Plugins registry | Plugin code complete at `obsidian-plugin/`. Manual install path documented; registry submission deferred. |

--- a/docs/INSTALL_MODES.md
+++ b/docs/INSTALL_MODES.md
@@ -8,7 +8,7 @@ needs and skips the rest.
 |---|---|---|---|
 | **Researcher / dev** | You're reading the source, running benchmarks, contributing PRs | ~5 min | $0 |
 | **Obsidian power-user** | You have a vault and want Atlas watching it for contradictions | ~10 min | $0–$1/day in API calls if you turn on LLM extraction |
-| **Agent-runtime integration** | You're building a Python/MCP integration; native latest-Hermes/OpenClaw packages remain planned | varies | $0 |
+| **Agent-runtime integration** | You're building a Python/MCP integration or installing native Hermes/OpenClaw memory | varies | $0 |
 
 Each section is self-contained — you should not need to read the others to
 get going.
@@ -125,9 +125,8 @@ pip install -e .         # core only — no LLM, no embeddings
 PYTHONPATH=. python scripts/demo_runtime_adapters.py  # no Docker
 ```
 
-That command proves Hermes-shaped and OpenClaw-shaped storage, retrieval,
-fetch/list, and forgetting. The current upstream-native packaging boundary is
-documented in [`RUNTIME_ADAPTERS.md`](RUNTIME_ADAPTERS.md).
+That command proves the SDK-neutral cores. Native packages and their pinned-host
+proof are documented in [`RUNTIME_ADAPTERS.md`](RUNTIME_ADAPTERS.md).
 
 Pick the surface for your runtime:
 
@@ -173,11 +172,10 @@ memory_id = await memory.put(item)
 hits = await memory.search("pricing decision", k=5)
 ```
 
-This is a functional Python adapter core, not a native current-Hermes plugin.
-Hermes Agent now requires a subclass of its lifecycle-based `MemoryProvider`
-with `initialize`, `prefetch`, `sync_turn`, tool dispatch, and shutdown hooks.
-Atlas will not claim native Hermes installation until that wrapper passes an
-actual Hermes-process round trip.
+For native Hermes installation, use the package and Mac/Linux or Windows
+installer in [`integrations/hermes-atlas/`](../integrations/hermes-atlas/).
+It implements the current lifecycle-based `MemoryProvider` contract and is
+tested against the pinned Hermes host with Neo4j unavailable.
 
 ### OpenClaw
 
@@ -190,12 +188,11 @@ memory_id = await atlas.store("Customer prefers weekly summaries", metadata)
 hits = await atlas.recall("reporting preference", k=5)
 ```
 
-The factory returns `AtlasOpenClawPlugin`, the SDK-neutral Python core.
-Current OpenClaw cannot load this Python factory as a native memory plugin. It
-expects a TypeScript package using its plugin SDK and
-`registerMemoryCapability`. The core operations above are real; the npm
-wrapper remains planned and must pass inside an actual OpenClaw process before
-Atlas calls it drop-in.
+The factory returns the SDK-neutral Python core, `AtlasOpenClawPlugin`. For native OpenClaw, install
+the checksum-pinned tarball from
+[`integrations/openclaw-atlas/`](../integrations/openclaw-atlas/), then select
+`atlas-memory` as the memory slot. That TypeScript package is tested through
+the real pinned OpenClaw CLI and runtime loader.
 
 What you get without Neo4j:
 - SQLite-backed storage, deterministic lexical retrieval, fetch/list, and

--- a/docs/RUNTIME_ADAPTERS.md
+++ b/docs/RUNTIME_ADAPTERS.md
@@ -62,39 +62,32 @@ Docker is the documented local setup, not the only possible deployment.
 Neo4j Desktop, a native Neo4j service, or Aura can provide the same Bolt
 endpoint.
 
-## Upstream compatibility boundary
+## Native upstream packages
 
-The modules `atlas_core.adapters.hermes` and
-`atlas_core.adapters.openclaw` are functional SDK-neutral adapter cores. They
-are not currently installable native plugins for the latest upstream runtimes.
+The modules `atlas_core.adapters.hermes` and `atlas_core.adapters.openclaw`
+remain functional SDK-neutral Python cores. Native host packages now ship too:
 
-Current Hermes Agent expects a Python plugin that subclasses
-`agent.memory_provider.MemoryProvider` and implements lifecycle hooks including
-`initialize`, `prefetch`, `sync_turn`, tool schemas, tool dispatch, and
-`shutdown` ([upstream contract](https://github.com/NousResearch/hermes-agent/blob/main/agent/memory_provider.py)). Atlas's older four-method class is the working persistence and
-retrieval core a native wrapper can call, but it is not that wrapper.
+- `integrations/hermes-atlas/` subclasses Hermes's current `MemoryProvider`
+  and implements initialization, prefetch, nonblocking turn capture, tools,
+  pre-compression, backup/config, and acknowledged shutdown.
+- `integrations/openclaw-atlas/` is a TypeScript `kind: memory` package using
+  OpenClaw's public plugin SDK and `registerMemoryCapability`. It registers
+  `memory_search`, `memory_get`, `memory_store`, and `memory_forget`.
 
-Current OpenClaw expects a TypeScript package built on its plugin SDK, with a
-memory manifest and `registerMemoryCapability`. A Python `plugin(config)`
-factory cannot be loaded directly by current OpenClaw. Atlas's Python class is
-the tested storage/retrieval core, not the final npm package. See OpenClaw's
-[plugin SDK overview](https://docs.openclaw.ai/plugins/sdk-overview).
-
-Until those native packages are built and tested inside the actual upstream
-processes, Atlas will not label them drop-in integrations. Native packaging is
-tracked in [#27 for Hermes](https://github.com/RichSchefren/atlas/issues/27)
-and [#26 for OpenClaw](https://github.com/RichSchefren/atlas/issues/26).
+Dedicated CI installs each package into its pinned upstream host with Neo4j
+pointed at a dead endpoint. The OpenClaw gate also installs the release tarball
+through the real CLI and requires a loaded runtime, all four tools, and zero
+diagnostics. Package-specific setup is in each integration's README.
 
 ## Integration choices today
 
 1. Python runtimes can construct `AtlasHermesProvider.from_config(...)` or
    `AtlasOpenClawPlugin` and use the portable operations directly.
 2. Any runtime can call the four `memory.*` tools through Atlas MCP or HTTP.
-3. Hermes and OpenClaw plugin authors can wrap the portable surface without
-   requiring the Neo4j tier.
+3. Hermes and OpenClaw users can install the native packages without requiring
+   the Neo4j tier.
 4. Teams that want Ripple and AGM behavior can point the same Atlas instance
    at Neo4j; the adapter-facing memory calls do not change.
 
-The acceptance standard for future native packages is a real upstream-process
-round trip: capture a turn, retrieve it in a later turn, fetch it by ID, forget
-it, and prove it no longer appears—all in both Hermes Agent and OpenClaw CI.
+The native acceptance standard is enforced in `.github/workflows/hermes-native.yml`
+and `.github/workflows/openclaw-native.yml`.


### PR DESCRIPTION
## Summary
- replace the obsolete native-packaging boundary with the shipped Hermes MemoryProvider and OpenClaw TypeScript plugin
- link both package installation paths from the README and install-mode guide
- keep Neo4j and Docker explicitly optional for portable/runtime memory and required only for the cognitive graph tier

## Verification
- 333 scoped unit and runtime-adapter integration tests passed
- stale planned/not-native claim scan passed

Closes the public documentation gap after #29 and #30.