### PR TITLE
Repair trust, Ripple, and API security boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,25 @@ on:
     branches: [main, master]
 
 jobs:
+  obsidian-plugin:
+    name: obsidian plugin bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: obsidian-plugin/package-lock.json
+      - name: Install locked plugin dependencies
+        run: npm ci --prefix obsidian-plugin
+      - name: Reject vulnerable plugin dependencies
+        run: npm audit --prefix obsidian-plugin --audit-level=moderate
+      - name: Build production plugin bundle
+        run: |
+          npm run build --prefix obsidian-plugin
+          test -s obsidian-plugin/main.js
+
   windows-sqlite-and-unit:
     name: windows py3.14 unit + sqlite lifecycle
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ neo4j-plugins/
 .env.local
 node_modules/
 obsidian-plugin/main.js
-obsidian-plugin/package-lock.json
 
 # Ruff cache
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Atlas is a Python service that maintains a continuously-updated typed knowledge 
 
 1. **Quarantines the claim** until corroborated by an independent source family
 2. **Promotes corroborated claims** to a hash-chained append-only ledger
-3. **Triggers Ripple propagation** when a ledger entry creates a revision: traverses `Depends_On` edges, re-evaluates downstream beliefs with confidence propagation, surfaces emergent contradictions
+3. **Triggers Ripple propagation** after a ledger-approved belief is materialized: traverses declared `Depends_On` edges, re-evaluates downstream beliefs with confidence propagation, surfaces emergent contradictions. Atlas does not infer dependency edges from prose; callers declare them through the AGM/MCP surfaces.
 4. **Routes resolution** — reassessments persist as proposals; strategic contradictions also go to a markdown adjudication queue you resolve in Obsidian. Atlas does not claim an automatic proposal consumer until that graph-tier writer ships.
 
 All revisions are AGM-compliant (K\*2–K\*6 + Hansson Relevance + Core-Retainment), formally verified against Kumiho's correspondence theorem (arxiv:2603.17244).
@@ -381,7 +381,7 @@ Full design docs are checked into the repo at [`paper/atlas.md`](paper/atlas.md)
 Atlas ships with three concurrent surfaces:
 
 - **MCP**: 17 Atlas-original tools — the graph/Ripple, adjudication, quarantine, ledger, working-memory, lineage, and sharing tools plus portable `memory.search`, `memory.get`, `memory.list`, and `memory.forget`. Stdio JSON-RPC bridge for Claude Code via `python -m atlas_core.adapters.claude_code`. Read-only vs mutation classification at [`docs/PROPOSAL_VS_MUTATION.md`](docs/PROPOSAL_VS_MUTATION.md).
-- **HTTP**: FastAPI on `localhost:9879` mirrors the MCP surface for non-MCP clients (the dashboard, curl, integration tests). Endpoints: `/health`, `/tools`, `/tools/{name}`, `/verify-chain`.
+- **HTTP**: FastAPI on `localhost:9879` mirrors the MCP surface for non-MCP clients. `/health` is public; every data or mutation route requires `Authorization: Bearer $(cat ~/.atlas/http-token)`. Browser access is limited to an explicit origin allowlist (`ATLAS_HTTP_ALLOWED_ORIGINS`). Endpoints: `/health`, `/tools`, `/tools/{name}`, `/verify-chain`, `/events`.
 - **Portable cognitive HTTP**: the authenticated, single-scope localhost v1
   service in `integrations/cognitive-service/`. Native Hermes, OpenClaw, and
   the GBrain bridge manage this
@@ -482,7 +482,7 @@ If you want to break Atlas, [TESTING.md](TESTING.md) has five concrete paths fro
 |---|---|
 | `RippleEngine.propagate()` runs the full cascade end-to-end | `./demo.sh` |
 | AGM compliance — K\*2 / K\*3 / K\*4 / K\*5 / K\*6 / Hansson Relevance / Core-Retainment | `pytest tests/integration/test_agm_compliance.py -v` (49/49) |
-| Hash-chained SHA-256 ledger with `verify_chain()` tamper detection | `pytest tests/unit/test_ledger.py -v` |
+| Versioned SHA-256 ledger that hash-binds content and audit fields, with legacy-chain verification | `pytest tests/unit/test_ledger.py -v` |
 | Trust quarantine → corroboration → ledger state machine | `pytest tests/unit/test_quarantine.py -v` |
 | Six ingestion extractors (Vault, Limitless, Screenpipe, Claude sessions, Fireflies stub, iMessage) | `pytest tests/unit/test_ingestion.py tests/unit/test_ingestion_extra.py -v` |
 | Entity resolution cascade (alias → fuzzy → LLM fallback) | `pytest tests/unit/test_resolution.py -v` |
@@ -492,7 +492,8 @@ If you want to break Atlas, [TESTING.md](TESTING.md) has five concrete paths fro
 | Multi-tenant tenant context + sharing policy + federated adjudication | `pytest tests/unit/test_multi_tenant.py -v` |
 | Adjudication round-trip — markdown queue → AGM revise → ledger SUPERSEDE → archive | `pytest tests/integration/test_adjudication_resolver.py -v` |
 | 17 MCP tools dispatch correctly via stdio JSON-RPC | `pytest tests/integration/test_mcp_server.py tests/integration/test_claude_code_stdio.py -v` |
-| FastAPI surface with CORS + Server-Sent Events stream | `pytest tests/integration/test_http_server.py tests/unit/test_events_broadcaster.py -v` |
+| Bearer-authenticated FastAPI surface with allowlisted CORS + Server-Sent Events | `pytest tests/unit/test_http_server_security.py tests/integration/test_http_server.py tests/unit/test_events_broadcaster.py -v` |
+| Ledger-approved graph materialization triggers Ripple once per ledger event | `pytest tests/unit/test_materializer_ripple.py tests/integration/test_candidate_materialization.py -v` |
 | Hermes/OpenClaw adapter storage, retrieval, fetch, list, and forget without Neo4j | `python scripts/demo_runtime_adapters.py` |
 | Native OpenClaw host cognition and GBrain page-linked cognition | `.github/workflows/openclaw-native.yml` and `.github/workflows/gbrain-native.yml` |
 | Kumiho-compat gRPC handlers (10 of 51 methods wired, 41 return UNIMPLEMENTED) | `pytest tests/integration/test_grpc_handlers.py -v` |

--- a/atlas_core/api/__init__.py
+++ b/atlas_core/api/__init__.py
@@ -4,7 +4,11 @@
 Spec: 05 - Atlas Architecture & Schema § 2 (API Layer)
 """
 
-from atlas_core.api.http_server import DEFAULT_HTTP_PORT, create_http_app
+from atlas_core.api.http_server import (
+    DEFAULT_ALLOWED_ORIGINS,
+    DEFAULT_HTTP_PORT,
+    create_http_app,
+)
 from atlas_core.api.mcp_server import (
     ATLAS_MCP_TOOLS,
     AtlasMCPServer,
@@ -19,4 +23,5 @@ __all__ = [
     "MCPToolResult",
     "create_http_app",
     "DEFAULT_HTTP_PORT",
+    "DEFAULT_ALLOWED_ORIGINS",
 ]

--- a/atlas_core/api/api_app.py
+++ b/atlas_core/api/api_app.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from atlas_core.api.auth import load_or_create_http_token
+
 
 def _build_app():
     from neo4j import AsyncGraphDatabase
@@ -24,6 +26,15 @@ def _build_app():
         "ATLAS_DATA_DIR", str(Path.home() / ".atlas"),
     ))
     data_dir.mkdir(parents=True, exist_ok=True)
+    bearer_token = load_or_create_http_token(data_dir)
+    allowed_origins = tuple(
+        origin.strip()
+        for origin in os.environ.get(
+            "ATLAS_HTTP_ALLOWED_ORIGINS",
+            "app://obsidian.md,http://localhost:8765,http://127.0.0.1:8765",
+        ).split(",")
+        if origin.strip()
+    )
 
     driver = AsyncGraphDatabase.driver(
         os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
@@ -37,7 +48,11 @@ def _build_app():
     server = AtlasMCPServer(
         driver=driver, quarantine=quarantine, ledger=ledger,
     )
-    return create_http_app(mcp_server=server)
+    return create_http_app(
+        mcp_server=server,
+        bearer_token=bearer_token,
+        allowed_origins=allowed_origins,
+    )
 
 
 app = _build_app()

--- a/atlas_core/api/auth.py
+++ b/atlas_core/api/auth.py
@@ -1,0 +1,56 @@
+"""Per-install authentication material for the localhost Atlas API."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from pathlib import Path
+
+
+def _read_token_file(token_path: Path) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(token_path, flags)
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"Atlas HTTP token is not a regular file: {token_path}")
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            descriptor = -1
+            return handle.read().strip()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def load_or_create_http_token(data_dir: Path) -> str:
+    """Load a configured token or create an owner-readable per-install token."""
+    configured = os.environ.get("ATLAS_HTTP_TOKEN")
+    if configured:
+        if len(configured) < 32:
+            raise ValueError("ATLAS_HTTP_TOKEN must contain at least 32 characters")
+        return configured
+
+    token_path = data_dir / "http-token"
+    try:
+        token = _read_token_file(token_path)
+    except FileNotFoundError:
+        token = secrets.token_urlsafe(32)
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        try:
+            descriptor = os.open(token_path, flags, 0o600)
+        except FileExistsError:
+            token = _read_token_file(token_path)
+        else:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(f"{token}\n")
+    if len(token) < 32:
+        raise ValueError(f"invalid Atlas HTTP token in {token_path}")
+    return token

--- a/atlas_core/api/auth.py
+++ b/atlas_core/api/auth.py
@@ -5,7 +5,29 @@ from __future__ import annotations
 import os
 import secrets
 import stat
+import subprocess
 from pathlib import Path
+
+
+def _secure_windows_token_file(token_path: Path) -> None:
+    """Replace inherited Windows ACLs with one explicit user grant."""
+    username = os.environ.get("USERNAME")
+    if not username:
+        raise RuntimeError("USERNAME is required to secure the Atlas HTTP token")
+    domain = os.environ.get("USERDOMAIN")
+    principal = f"{domain}\\{username}" if domain else username
+    subprocess.run(
+        [
+            "icacls",
+            str(token_path),
+            "/inheritance:r",
+            "/grant:r",
+            f"{principal}:(F)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _read_token_file(token_path: Path) -> str:
@@ -15,14 +37,17 @@ def _read_token_file(token_path: Path) -> str:
         file_stat = os.fstat(descriptor)
         if not stat.S_ISREG(file_stat.st_mode):
             raise ValueError(f"Atlas HTTP token is not a regular file: {token_path}")
-        if hasattr(os, "fchmod"):
+        if os.name != "nt":
             os.fchmod(descriptor, 0o600)
         with os.fdopen(descriptor, encoding="utf-8") as handle:
             descriptor = -1
-            return handle.read().strip()
+            token = handle.read().strip()
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+    if os.name == "nt":
+        _secure_windows_token_file(token_path)
+    return token
 
 
 def load_or_create_http_token(data_dir: Path) -> str:
@@ -51,6 +76,8 @@ def load_or_create_http_token(data_dir: Path) -> str:
         else:
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
                 handle.write(f"{token}\n")
+            if os.name == "nt":
+                _secure_windows_token_file(token_path)
     if len(token) < 32:
         raise ValueError(f"invalid Atlas HTTP token in {token_path}")
     return token

--- a/atlas_core/api/http_server.py
+++ b/atlas_core/api/http_server.py
@@ -13,6 +13,8 @@ Spec: 05 - Atlas Architecture & Schema § 2
 from __future__ import annotations
 
 import logging
+import secrets
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -27,19 +29,32 @@ log = logging.getLogger(__name__)
 DEFAULT_HTTP_PORT: int = 9879
 """Atlas HTTP port — vault-search uses 9878, Atlas takes 9879."""
 
+DEFAULT_ALLOWED_ORIGINS: tuple[str, ...] = (
+    "app://obsidian.md",
+    "http://localhost:8765",
+    "http://127.0.0.1:8765",
+)
+"""Browser origins trusted by the local API unless explicitly configured."""
+
 
 # Defined at module scope (not inside create_http_app) so FastAPI can resolve
 # the annotation. `from __future__ import annotations` turns annotations into
 # strings, and FastAPI resolves them against module globals.
 from pydantic import BaseModel as _BaseModel  # noqa: E402  (intentional placement; see comment above)
 from pydantic import Field as _Field  # noqa: E402
+from starlette.requests import Request as _Request  # noqa: E402
 
 
 class DispatchBody(_BaseModel):
     params: dict[str, Any] = _Field(default_factory=dict)
 
 
-def create_http_app(*, mcp_server: AtlasMCPServer) -> FastAPI:
+def create_http_app(
+    *,
+    mcp_server: AtlasMCPServer,
+    bearer_token: str,
+    allowed_origins: Sequence[str] = DEFAULT_ALLOWED_ORIGINS,
+) -> FastAPI:
     """Build the FastAPI app wrapping the MCP server.
 
     Endpoints:
@@ -48,8 +63,14 @@ def create_http_app(*, mcp_server: AtlasMCPServer) -> FastAPI:
       POST /tools/{name}    — dispatch a tool with JSON body params
       GET  /verify-chain    — shortcut for ledger.verify_chain
     """
-    from fastapi import FastAPI, HTTPException
+    from fastapi import Depends, FastAPI, HTTPException, status
     from fastapi.middleware.cors import CORSMiddleware
+
+    if len(bearer_token) < 32:
+        raise ValueError("bearer_token must contain at least 32 characters")
+    trusted_origins = list(allowed_origins)
+    if "*" in trusted_origins:
+        raise ValueError("wildcard CORS origins are not permitted")
 
     app = FastAPI(
         title="Atlas API",
@@ -60,20 +81,30 @@ def create_http_app(*, mcp_server: AtlasMCPServer) -> FastAPI:
         ),
     )
 
-    # Permissive CORS — Atlas runs local-first on the user's own
-    # machine, so the threat model is empty here. The Obsidian plugin
-    # and the local viewer pages (served from :8765 or any other port)
-    # need to subscribe to /events from a different origin; without
-    # CORS, browsers block the EventSource handshake and the page
-    # shows "error — is the API server running?" even when the API
-    # is healthy. See site/live-real.html for the consumer.
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=trusted_origins,
         allow_credentials=False,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST"],
+        allow_headers=["Authorization", "Content-Type"],
     )
+
+    async def require_bearer(request: _Request) -> None:
+        supplied = request.headers.get("Authorization", "")
+        scheme, _, token = supplied.partition(" ")
+        valid = (
+            scheme.lower() == "bearer"
+            and bool(token)
+            and secrets.compare_digest(token, bearer_token)
+        )
+        if not valid:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="valid bearer token required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    authenticated = [Depends(require_bearer)]
 
     @app.get("/health")
     async def health() -> dict[str, Any]:
@@ -83,25 +114,25 @@ def create_http_app(*, mcp_server: AtlasMCPServer) -> FastAPI:
             "version": "0.1.0a1",
         }
 
-    @app.get("/tools")
+    @app.get("/tools", dependencies=authenticated)
     async def list_tools() -> dict[str, Any]:
         return {"tools": mcp_server.list_tools()}
 
-    @app.post("/tools/{tool_name}")
+    @app.post("/tools/{tool_name}", dependencies=authenticated)
     async def dispatch_tool(tool_name: str, body: DispatchBody) -> dict[str, Any]:
         result = await mcp_server.dispatch(tool_name, body.params)
         if not result.ok:
             raise HTTPException(status_code=400, detail=result.error)
         return {"ok": True, "result": result.result}
 
-    @app.get("/verify-chain")
+    @app.get("/verify-chain", dependencies=authenticated)
     async def verify_chain() -> dict[str, Any]:
         result = await mcp_server.dispatch("ledger.verify_chain", {})
         if not result.ok:
             raise HTTPException(status_code=500, detail=result.error)
         return result.result
 
-    @app.get("/events")
+    @app.get("/events", dependencies=authenticated)
     async def events_stream():
         """Server-Sent Events stream for live Atlas activity. The
         Obsidian plugin and live-Ripple visualization both subscribe.
@@ -123,7 +154,7 @@ def create_http_app(*, mcp_server: AtlasMCPServer) -> FastAPI:
             event_generator(), media_type="text/event-stream",
         )
 
-    @app.get("/events/stats")
+    @app.get("/events/stats", dependencies=authenticated)
     async def events_stats() -> dict[str, Any]:
         """Liveness check for the event broadcaster — useful for
         debugging when the Obsidian plugin shows no events."""

--- a/atlas_core/graphiti.py
+++ b/atlas_core/graphiti.py
@@ -1,8 +1,8 @@
-"""AtlasGraphiti — main entry point. Subclass of Graphiti that adds Ripple + AGM.
+"""AtlasGraphiti — Graphiti ingestion entry point for Atlas.
 
-Phase 2 Week 1 scaffold. Ripple, trust layer, ledger are stubs to be filled in
-during Weeks 2-4. The integration pattern (subclass + super().add_episode + Ripple
-hook) is locked from `06 - Ripple Algorithm Spec.md`.
+Raw Graphiti extraction is intentionally separate from trusted Ripple execution.
+The approved-candidate materializer owns the post-promotion Ripple hook because
+only it has a ledger event, a stable belief kref, and confidence transition.
 """
 
 from __future__ import annotations
@@ -14,8 +14,6 @@ from typing import TYPE_CHECKING, Any
 from graphiti_core import Graphiti
 
 if TYPE_CHECKING:
-    from graphiti_core.graphiti import AddEpisodeResults
-
     from atlas_core.ripple.engine import RippleEngine
     from atlas_core.trust.ledger import HashChainedLedger
     from atlas_core.trust.quarantine import QuarantineStore
@@ -46,11 +44,10 @@ def _default_anthropic_llm_client() -> Any | None:
 
 
 class AtlasGraphiti(Graphiti):
-    """Atlas's main entry point. Subclasses Graphiti to add Ripple + AGM-compliant revision.
+    """Atlas's Graphiti entry point with Atlas's default LLM configuration.
 
-    Architecturally identical to upstream Graphiti for ingestion. The Atlas-specific
-    behavior is the post-extraction hook that triggers Ripple propagation when edges
-    are promoted to the trust ledger.
+    Raw extracted edges are not trusted facts and never trigger Ripple here.
+    ``materialize_approved_candidates`` runs Ripple after ledger promotion.
 
     AGM-managed edges (SUPERSEDES, DEPENDS_ON, DERIVED_FROM, CONTRADICTS, SUPPORTS)
     bypass Graphiti's LLM-driven `resolve_extracted_edges` to preserve formal
@@ -76,36 +73,8 @@ class AtlasGraphiti(Graphiti):
         self.ripple_engine = ripple_engine
         self.quarantine_store = quarantine_store
         self.ledger = ledger
-
-    async def add_episode(self, *args, **kwargs) -> AddEpisodeResults:
-        """Override Graphiti's add_episode to run Ripple after standard ingestion.
-
-        Sequencing rule: Ripple fires only on facts promoted to the ledger
-        (trust = 1.0). Never on quarantined facts. Prevents graph oscillation
-        from noisy capture streams (Phase 0 design lock; see Ripple Spec § 4).
-        """
-        results = await super().add_episode(*args, **kwargs)
-
-        if self.ripple_engine and self.ledger:
-            promoted_edges = [
-                edge
-                for edge in results.edges
-                if self.ledger.is_promoted(edge.uuid)
-            ]
-            invalidated_edges = [
-                edge for edge in results.edges if edge.expired_at is not None
-            ]
-
-            if promoted_edges:
-                log.debug(
-                    "Triggering Ripple on %d promoted edges (%d invalidated)",
-                    len(promoted_edges),
-                    len(invalidated_edges),
-                )
-                await self.ripple_engine.propagate(
-                    new_edges=promoted_edges,
-                    invalidated_edges=invalidated_edges,
-                    episode=results.episode,
-                )
-
-        return results
+        if ripple_engine is not None or ledger is not None:
+            log.warning(
+                "AtlasGraphiti no longer triggers Ripple from raw extracted edges; "
+                "run ledger-approved candidates through materialize_approved_candidates"
+            )

--- a/atlas_core/ingestion/materializer.py
+++ b/atlas_core/ingestion/materializer.py
@@ -9,16 +9,19 @@ duplicates.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from atlas_core.revision.agm import revise
 from atlas_core.revision.uri import Kref
 
 if TYPE_CHECKING:
     from neo4j import AsyncDriver
 
+    from atlas_core.ripple.engine import RippleEngine
     from atlas_core.trust import QuarantineStore
 
 
@@ -27,16 +30,37 @@ class MaterializationReport:
     attempted: int = 0
     materialized: int = 0
     failed: int = 0
+    ripple_attempted: int = 0
+    ripple_completed: int = 0
+    ripple_failed: int = 0
     belief_krefs: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _MaterializedCandidate:
+    belief_kref: str
+    previous_confidence: float
+    ripple_ledger_event_id: str | None
+    is_current: bool
+
+
 def belief_kref_for_candidate(candidate: dict[str, Any]) -> str:
-    """Mint one stable belief kref per deduplicated candidate."""
-    subject = Kref.parse(candidate["subject_kref"])
+    """Mint one stable belief root per subject, predicate, and scope.
+
+    Candidate object values deliberately do not participate in this identity:
+    a changed value is an AGM revision of the same logical belief.
+    """
+    subject = Kref.parse(candidate["subject_kref"]).root_kref()
+    identity = json.dumps(
+        [subject.to_string(), candidate["predicate"], candidate["scope"]],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    suffix = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
     return (
         f"kref://{subject.project}/IngestedBeliefs/"
-        f"candidate_{candidate['candidate_id']}.belief"
+        f"{subject.item}_{suffix}.belief"
     )
 
 
@@ -44,28 +68,37 @@ async def materialize_candidate(
     driver: AsyncDriver,
     candidate: dict[str, Any],
 ) -> str:
-    """Upsert one approved candidate as ``(:Belief)-[:ABOUT]->(:AtlasItem)``."""
-    if candidate.get("status") != "approved" or not candidate.get("ledger_event_id"):
-        raise ValueError("candidate must be ledger-approved before graph materialization")
+    """Project one approved candidate as an immutable AGM belief revision."""
+    state = await _materialize_candidate_state(driver, candidate)
+    return state.belief_kref
 
-    subject = Kref.parse(candidate["subject_kref"])
-    belief_kref = belief_kref_for_candidate(candidate)
-    now = datetime.now(timezone.utc).isoformat()
-    evidence_json = candidate.get("evidence_refs_json") or "[]"
-    # Validate before sending the serialized evidence into Neo4j.
-    json.loads(evidence_json)
 
+async def _project_current_revision(
+    driver: AsyncDriver,
+    *,
+    candidate: dict[str, Any],
+    subject: Kref,
+    belief_kref: str,
+    revision_kref: str,
+    previous_confidence: float,
+    evidence_json: str,
+    now: str,
+) -> str:
+    """Update the queryable current-state projection for an AGM revision."""
     cypher = """
     MERGE (subject:AtlasItem {kref: $subject_kref})
       ON CREATE SET subject.created_at = $now,
                     subject.kind = $subject_kind,
                     subject.deprecated = false
-    MERGE (belief:AtlasItem:Belief {candidate_id: $candidate_id})
-      ON CREATE SET belief.kref = $belief_kref,
-                    belief.created_at = $now,
-                    belief.materialized_at = $now,
-                    belief.deprecated = false
-    SET belief.predicate = $predicate,
+    WITH subject
+    MATCH (belief:AtlasItem {root_kref: $belief_kref})
+    SET belief:Belief,
+        belief.kref = $belief_kref,
+        belief.materialized_at = coalesce(belief.materialized_at, $now),
+        belief.deprecated = false,
+        belief.candidate_id = $candidate_id,
+        belief.current_revision_kref = $revision_kref,
+        belief.predicate = $predicate,
         belief.object_value = $object_value,
         belief.text = $text,
         belief.assertion_type = $assertion_type,
@@ -76,6 +109,13 @@ async def materialize_candidate(
         belief.ledger_event_id = $ledger_event_id,
         belief.evidence_refs_json = $evidence_json,
         belief.last_materialized_at = $now
+    WITH subject, belief
+    MATCH (:AtlasTag {name: 'current', root_kref: $belief_kref})
+          -[:POINTS_TO]->(revision:AtlasRevision {kref: $revision_kref})
+    SET revision.ledger_event_id = $ledger_event_id,
+        revision.candidate_id = $candidate_id,
+        revision.confidence_score = $confidence,
+        revision.previous_confidence = $previous_confidence
     MERGE (belief)-[about:ABOUT]->(subject)
       ON CREATE SET about.created_at = $now
     RETURN belief.kref AS belief_kref
@@ -86,6 +126,7 @@ async def materialize_candidate(
             subject_kref=subject.root_kref().to_string(),
             subject_kind=subject.kind,
             belief_kref=belief_kref,
+            revision_kref=revision_kref,
             candidate_id=candidate["candidate_id"],
             predicate=candidate["predicate"],
             object_value=candidate["object_value"],
@@ -97,6 +138,7 @@ async def materialize_candidate(
             lane=candidate["lane"],
             ledger_event_id=candidate["ledger_event_id"],
             evidence_json=evidence_json,
+            previous_confidence=previous_confidence,
             now=now,
         )
         record = await result.single()
@@ -105,16 +147,164 @@ async def materialize_candidate(
     return str(record["belief_kref"])
 
 
+async def _materialize_candidate_state(
+    driver: AsyncDriver,
+    candidate: dict[str, Any],
+) -> _MaterializedCandidate:
+    """Apply an idempotent AGM revision and return its Ripple transition."""
+    if candidate.get("status") != "approved" or not candidate.get("ledger_event_id"):
+        raise ValueError("candidate must be ledger-approved before graph materialization")
+
+    subject = Kref.parse(candidate["subject_kref"])
+    belief_kref = belief_kref_for_candidate(candidate)
+    now = datetime.now(timezone.utc).isoformat()
+    evidence_json = candidate.get("evidence_refs_json") or "[]"
+    evidence = json.loads(evidence_json)
+
+    ledger_marker = f'"ledger_event_id":{json.dumps(candidate["ledger_event_id"])}'
+    state_cypher = """
+    OPTIONAL MATCH (existing:AtlasRevision {root_kref: $belief_kref})
+    WHERE existing.ledger_event_id = $ledger_event_id
+       OR existing.content_json CONTAINS $ledger_marker
+    OPTIONAL MATCH (existing)-[:SUPERSEDES]->(prior:AtlasRevision)
+    OPTIONAL MATCH (root:AtlasItem {root_kref: $belief_kref})
+    OPTIONAL MATCH (:AtlasTag {name: 'current', root_kref: $belief_kref})
+                   -[:POINTS_TO]->(current:AtlasRevision)
+    RETURN existing.kref AS existing_revision_kref,
+           existing.previous_confidence AS existing_previous_confidence,
+           prior.content_json AS prior_content_json,
+           current.kref AS current_revision_kref,
+           current.content_json AS current_content_json,
+           root.ripple_ledger_event_id AS ripple_ledger_event_id
+    """
+    async with driver.session() as session:
+        result = await session.run(
+            state_cypher,
+            belief_kref=belief_kref,
+            ledger_event_id=candidate["ledger_event_id"],
+            ledger_marker=ledger_marker,
+        )
+        state_record = await result.single()
+    if state_record is None:
+        raise RuntimeError(f"Neo4j returned no state for {candidate['candidate_id']}")
+
+    existing_revision_kref = state_record["existing_revision_kref"]
+    if existing_revision_kref is not None:
+        previous_confidence = state_record["existing_previous_confidence"]
+        if previous_confidence is None:
+            prior_content_json = state_record["prior_content_json"]
+            prior_content = (
+                json.loads(prior_content_json) if prior_content_json else {}
+            )
+            previous_confidence = prior_content.get("confidence", 0.0)
+        previous_confidence = float(previous_confidence)
+        is_current = (
+            existing_revision_kref == state_record["current_revision_kref"]
+        )
+        if is_current:
+            await _project_current_revision(
+                driver,
+                candidate=candidate,
+                subject=subject,
+                belief_kref=belief_kref,
+                revision_kref=str(existing_revision_kref),
+                previous_confidence=previous_confidence,
+                evidence_json=evidence_json,
+                now=now,
+            )
+        return _MaterializedCandidate(
+            belief_kref=belief_kref,
+            previous_confidence=previous_confidence,
+            ripple_ledger_event_id=state_record["ripple_ledger_event_id"],
+            is_current=is_current,
+        )
+
+    current_content_json = state_record["current_content_json"]
+    current_content = (
+        json.loads(current_content_json) if current_content_json else {}
+    )
+    previous_confidence = float(current_content.get("confidence", 0.0))
+    content = {
+        "assertion_type": candidate["assertion_type"],
+        "candidate_id": candidate["candidate_id"],
+        "confidence": float(candidate["confidence"]),
+        "lane": candidate["lane"],
+        "ledger_event_id": candidate["ledger_event_id"],
+        "object_value": candidate["object_value"],
+        "predicate": candidate["predicate"],
+        "scope": candidate["scope"],
+        "trust_score": float(candidate["trust_score"]),
+    }
+    outcome = await revise(
+        driver,
+        Kref.parse(belief_kref),
+        content,
+        revision_reason=(
+            f"ledger promotion {candidate['ledger_event_id']} "
+            f"for candidate {candidate['candidate_id']}"
+        ),
+        evidence={"refs": evidence},
+        actor="atlas.materializer",
+    )
+
+    projected_kref = await _project_current_revision(
+        driver,
+        candidate=candidate,
+        subject=subject,
+        belief_kref=belief_kref,
+        revision_kref=outcome.new_revision_kref.to_string(),
+        previous_confidence=previous_confidence,
+        evidence_json=evidence_json,
+        now=now,
+    )
+    return _MaterializedCandidate(
+        belief_kref=projected_kref,
+        previous_confidence=previous_confidence,
+        ripple_ledger_event_id=state_record["ripple_ledger_event_id"],
+        is_current=True,
+    )
+
+
+async def _mark_ripple_completed(
+    driver: AsyncDriver,
+    *,
+    belief_kref: str,
+    ledger_event_id: str,
+) -> None:
+    """Record the ledger version whose Ripple cascade completed."""
+    async with driver.session() as session:
+        await session.run(
+            """
+            MATCH (belief:Belief {root_kref: $belief_kref})
+            MATCH (:AtlasTag {name: 'current', root_kref: $belief_kref})
+                  -[:POINTS_TO]->(revision:AtlasRevision)
+            WHERE revision.ledger_event_id = $ledger_event_id
+            SET belief.ripple_ledger_event_id = $ledger_event_id,
+                belief.ripple_completed_at = $now
+            """,
+            belief_kref=belief_kref,
+            ledger_event_id=ledger_event_id,
+            now=datetime.now(timezone.utc).isoformat(),
+        )
+
+
 async def materialize_approved_candidates(
     driver: AsyncDriver,
     quarantine: QuarantineStore,
+    *,
+    ripple_engine: RippleEngine | None = None,
 ) -> MaterializationReport:
-    """Project every approved candidate; continue and report per-item failures."""
+    """Project approved candidates and run Ripple once per ledger event.
+
+    Graph projection and Ripple are recoverable, at-least-once steps. The graph
+    records the ledger event whose cascade completed, so routine materializer
+    retries do not emit duplicate cascades.
+    """
     report = MaterializationReport()
     for candidate in quarantine.list_approved():
         report.attempted += 1
         try:
-            belief_kref = await materialize_candidate(driver, candidate)
+            state = await _materialize_candidate_state(driver, candidate)
         except Exception as exc:
             report.failed += 1
             report.errors.append(
@@ -122,5 +312,39 @@ async def materialize_approved_candidates(
             )
             continue
         report.materialized += 1
-        report.belief_krefs.append(belief_kref)
+        report.belief_krefs.append(state.belief_kref)
+
+        ledger_event_id = str(candidate["ledger_event_id"])
+        if (
+            ripple_engine is None
+            or not state.is_current
+            or state.ripple_ledger_event_id == ledger_event_id
+        ):
+            continue
+
+        report.ripple_attempted += 1
+        try:
+            cascade = await ripple_engine.propagate(
+                state.belief_kref,
+                old_confidence=state.previous_confidence,
+                new_confidence=float(candidate["confidence"]),
+                belief_text=(
+                    f"{candidate['predicate']}: {candidate['object_value']}"
+                ),
+            )
+            if not cascade.succeeded:
+                raise RuntimeError(cascade.error or "Ripple cascade failed")
+            await _mark_ripple_completed(
+                driver,
+                belief_kref=state.belief_kref,
+                ledger_event_id=ledger_event_id,
+            )
+        except Exception as exc:
+            report.ripple_failed += 1
+            report.errors.append(
+                f"{candidate['candidate_id']}: Ripple "
+                f"{type(exc).__name__}: {exc}"
+            )
+            continue
+        report.ripple_completed += 1
     return report

--- a/atlas_core/revision/agm.py
+++ b/atlas_core/revision/agm.py
@@ -148,6 +148,7 @@ async def revise(
       ON CREATE SET root.created_at = $timestamp,
                     root.kind = $kind,
                     root.deprecated = false
+    SET root.kref = $root_kref
     WITH root
 
     // Find prior revision at this tag (if any)

--- a/atlas_core/revision/agm.py
+++ b/atlas_core/revision/agm.py
@@ -143,12 +143,14 @@ async def revise(
     new_kref_str = root.with_revision(chash[:12]).to_string()
 
     cypher = """
-    // Ensure root item exists
-    MERGE (root:AtlasItem {root_kref: $root_kref})
+    // Ensure root item exists. `kref` is AtlasItem's canonical identity;
+    // matching it first lets AGM revise an existing live Belief node instead
+    // of creating a second root that collides with the uniqueness constraint.
+    MERGE (root:AtlasItem {kref: $root_kref})
       ON CREATE SET root.created_at = $timestamp,
                     root.kind = $kind,
                     root.deprecated = false
-    SET root.kref = $root_kref
+    SET root.root_kref = $root_kref
     WITH root
 
     // Find prior revision at this tag (if any)

--- a/atlas_core/trust/ledger.py
+++ b/atlas_core/trust/ledger.py
@@ -10,7 +10,9 @@ implements the actual cryptographic chain:
 
 Ripple's gating rule fires only on facts promoted to this ledger
 (trust = 1.0). Once promoted, the entry is cryptographically chained and
-tamper-evident — any post-hoc modification breaks `verify_chain()`.
+integrity-checkable — an uncoordinated post-hoc modification breaks
+`verify_chain()`. A local writer with database access can still rewrite the
+chain and recompute hashes unless the head hash is externally anchored.
 
 Spec: 05 - Atlas Architecture & Schema § 6
       03 - Atlas Technical Foundation § 4.4
@@ -184,11 +186,12 @@ def _compute_event_id_v2(
 
 
 class HashChainedLedger:
-    """Atlas's tamper-evident append-only ledger.
+    """Atlas's hash-chained append-only ledger.
 
     Every v2 event hashes the complete canonical event envelope.
-    Modifying ANY past event breaks `verify_chain()` because subsequent
-    event_ids no longer match their stored values.
+    Modifying a past event without recomputing the chain breaks
+    `verify_chain()` because subsequent event_ids no longer match their stored
+    values. This detects corruption; it is not a signature or external anchor.
 
     Atomic append via BEGIN IMMEDIATE; no concurrent writers can introduce
     chain gaps. `previous_hash` is stored explicitly as a column so the

--- a/atlas_core/trust/ledger.py
+++ b/atlas_core/trust/ledger.py
@@ -4,7 +4,7 @@ Bicameral's change_ledger.py uses random event_ids with no `previous_hash`
 field — the README claims hash-chained but the code is a sketch. Atlas
 implements the actual cryptographic chain:
 
-  event_id = SHA-256(previous_hash + canonical_payload)
+  event_id = SHA-256(canonical event envelope)
   chain_sequence: monotonic UNIQUE INTEGER for gap detection
   verify_chain(): walks from genesis to latest, validates every link
 
@@ -102,7 +102,8 @@ GENESIS_PREVIOUS_HASH: str = "genesis"
 """Sentinel used for the previous_hash field of the genesis event when
 computing event_id. Stored as NULL in the previous_hash column."""
 
-VERIFIER_VERSION: str = "atlas-verify-v1"
+VERIFIER_VERSION: str = "atlas-verify-v2"
+CURRENT_HASH_VERSION: int = 2
 
 
 def _utc_now() -> str:
@@ -139,13 +140,53 @@ def _compute_event_id(
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _compute_event_id_v2(
+    *,
+    previous_hash: str | None,
+    chain_sequence: int,
+    event_type: str,
+    recorded_at: str,
+    actor_id: str,
+    reason: str | None,
+    object_id: str,
+    target_object_id: str | None,
+    object_type: str,
+    root_id: str,
+    parent_id: str | None,
+    candidate_id: str | None,
+    policy_version: str | None,
+    payload_json: str,
+    metadata_json: str,
+) -> str:
+    """Hash every semantic and audit field in the v2 event envelope."""
+    envelope = {
+        "hash_version": CURRENT_HASH_VERSION,
+        "previous_hash": previous_hash or GENESIS_PREVIOUS_HASH,
+        "chain_sequence": chain_sequence,
+        "event_type": event_type,
+        "recorded_at": recorded_at,
+        "actor_id": actor_id,
+        "reason": reason,
+        "object_id": object_id,
+        "target_object_id": target_object_id,
+        "object_type": object_type,
+        "root_id": root_id,
+        "parent_id": parent_id,
+        "candidate_id": candidate_id,
+        "policy_version": policy_version,
+        "payload_json": payload_json,
+        "metadata_json": metadata_json,
+    }
+    return hashlib.sha256(_canonical_json(envelope).encode("utf-8")).hexdigest()
+
+
 # ─── HashChainedLedger ───────────────────────────────────────────────────────
 
 
 class HashChainedLedger:
     """Atlas's tamper-evident append-only ledger.
 
-    Every event is identified by SHA-256(previous_hash + canonical_payload).
+    Every v2 event hashes the complete canonical event envelope.
     Modifying ANY past event breaks `verify_chain()` because subsequent
     event_ids no longer match their stored values.
 
@@ -182,6 +223,32 @@ class HashChainedLedger:
         schema_sql = schema_path.read_text(encoding="utf-8")
         with self._connection() as conn:
             conn.executescript(schema_sql)
+            columns = {
+                row["name"]
+                for row in conn.execute("PRAGMA table_info(change_events)").fetchall()
+            }
+            if "hash_version" not in columns:
+                # Databases created before v2 retain their legacy hash contract.
+                conn.execute(
+                    "ALTER TABLE change_events "
+                    "ADD COLUMN hash_version INTEGER NOT NULL DEFAULT 1"
+                )
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO promotion_claims (candidate_id, event_id)
+                SELECT event.candidate_id, event.event_id
+                FROM change_events AS event
+                JOIN (
+                    SELECT candidate_id, MAX(chain_sequence) AS canonical_sequence
+                    FROM change_events
+                    WHERE event_type = ? AND candidate_id IS NOT NULL
+                    GROUP BY candidate_id
+                ) AS canonical
+                  ON canonical.candidate_id = event.candidate_id
+                 AND canonical.canonical_sequence = event.chain_sequence
+                """,
+                (EventType.PROMOTE.value,),
+            )
 
     # ── Append API ──────────────────────────────────────────────────────────
 
@@ -223,6 +290,15 @@ class HashChainedLedger:
         with self._connection() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
+                if (
+                    event_type_str == EventType.PROMOTE.value
+                    and candidate_id is not None
+                ):
+                    existing = self._promotion_event_row(conn, candidate_id)
+                    if existing is not None:
+                        conn.execute("COMMIT")
+                        return self._ledger_event_from_row(existing)
+
                 last = conn.execute(
                     "SELECT event_id, chain_sequence FROM change_events "
                     "ORDER BY chain_sequence DESC LIMIT 1"
@@ -235,32 +311,54 @@ class HashChainedLedger:
                     previous_hash = last["event_id"]
                     next_sequence = last["chain_sequence"] + 1
 
-                event_id = _compute_event_id(
+                event_id = _compute_event_id_v2(
                     previous_hash=previous_hash,
+                    chain_sequence=next_sequence,
                     event_type=event_type_str,
                     recorded_at=recorded_at,
+                    actor_id=actor_id,
+                    reason=reason,
                     object_id=object_id,
+                    target_object_id=target_object_id,
+                    object_type=object_type,
+                    root_id=root_id,
+                    parent_id=parent_id,
+                    candidate_id=candidate_id,
+                    policy_version=policy_version,
                     payload_json=payload_json,
+                    metadata_json=metadata_json,
                 )
 
                 conn.execute(
                     """
                     INSERT INTO change_events (
                         event_id, previous_hash, chain_sequence,
+                        hash_version,
                         event_type, recorded_at, actor_id, reason,
                         object_id, target_object_id, object_type,
                         root_id, parent_id, candidate_id, policy_version,
                         payload_json, metadata_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         event_id, previous_hash, next_sequence,
+                        CURRENT_HASH_VERSION,
                         event_type_str, recorded_at, actor_id, reason,
                         object_id, target_object_id, object_type,
                         root_id, parent_id, candidate_id, policy_version,
                         payload_json, metadata_json,
                     ),
                 )
+
+                if (
+                    event_type_str == EventType.PROMOTE.value
+                    and candidate_id is not None
+                ):
+                    conn.execute(
+                        "INSERT INTO promotion_claims (candidate_id, event_id) "
+                        "VALUES (?, ?)",
+                        (candidate_id, event_id),
+                    )
 
                 # Maintain typed_roots materialized view
                 if event_type_str in CREATE_EVENT_TYPES:
@@ -320,7 +418,7 @@ class HashChainedLedger:
 
     def verify_chain(self) -> ChainVerificationResult:
         """Walk the chain in chain_sequence order. Validate every event_id is
-        SHA-256(previous_hash + canonical_payload).
+        SHA-256 over its versioned hash contract.
 
         Returns ChainVerificationResult with first breakage point if any.
         Also writes an entry to the chain_verifications audit table.
@@ -328,8 +426,11 @@ class HashChainedLedger:
         with self._connection() as conn:
             rows = conn.execute(
                 """
-                SELECT chain_sequence, event_id, previous_hash,
-                       event_type, recorded_at, object_id, payload_json
+                SELECT chain_sequence, event_id, previous_hash, hash_version,
+                       event_type, recorded_at, actor_id, reason,
+                       object_id, target_object_id, object_type, root_id,
+                       parent_id, candidate_id, policy_version,
+                       payload_json, metadata_json
                 FROM change_events
                 ORDER BY chain_sequence ASC
                 """
@@ -390,13 +491,35 @@ class HashChainedLedger:
                 )
 
             # Recompute event_id from stored fields and compare
-            recomputed_id = _compute_event_id(
-                previous_hash=stored_prev_hash,
-                event_type=row["event_type"],
-                recorded_at=row["recorded_at"],
-                object_id=row["object_id"],
-                payload_json=row["payload_json"],
-            )
+            hash_version = int(row["hash_version"])
+            if hash_version == 1:
+                recomputed_id = _compute_event_id(
+                    previous_hash=stored_prev_hash,
+                    event_type=row["event_type"],
+                    recorded_at=row["recorded_at"],
+                    object_id=row["object_id"],
+                    payload_json=row["payload_json"],
+                )
+            elif hash_version == CURRENT_HASH_VERSION:
+                recomputed_id = _compute_event_id_v2(
+                    previous_hash=stored_prev_hash,
+                    chain_sequence=seq,
+                    event_type=row["event_type"],
+                    recorded_at=row["recorded_at"],
+                    actor_id=row["actor_id"],
+                    reason=row["reason"],
+                    object_id=row["object_id"],
+                    target_object_id=row["target_object_id"],
+                    object_type=row["object_type"],
+                    root_id=row["root_id"],
+                    parent_id=row["parent_id"],
+                    candidate_id=row["candidate_id"],
+                    policy_version=row["policy_version"],
+                    payload_json=row["payload_json"],
+                    metadata_json=row["metadata_json"] or "{}",
+                )
+            else:
+                recomputed_id = ""
             if recomputed_id != stored_event_id:
                 self._record_verification(
                     last_seq=last_intact_sequence,
@@ -454,8 +577,7 @@ class HashChainedLedger:
         """True iff there is at least one event in the ledger whose
         object_id, target_object_id, or candidate_id matches `edge_uuid`.
 
-        Used by AtlasGraphiti.add_episode to gate Ripple — only ledger
-        entries trigger Ripple cascades."""
+        Used by trust-boundary callers to confirm ledger promotion."""
         with self._connection() as conn:
             row = conn.execute(
                 """
@@ -475,6 +597,49 @@ class HashChainedLedger:
                 "SELECT * FROM change_events WHERE event_id = ?", (event_id,)
             ).fetchone()
         return dict(row) if row else None
+
+    @staticmethod
+    def _promotion_event_row(
+        conn: sqlite3.Connection, candidate_id: str
+    ) -> sqlite3.Row | None:
+        return conn.execute(
+            """
+            SELECT event.*
+            FROM promotion_claims AS claim
+            JOIN change_events AS event ON event.event_id = claim.event_id
+            WHERE claim.candidate_id = ?
+              AND event.candidate_id = claim.candidate_id
+              AND event.event_type = ?
+            """,
+            (candidate_id, EventType.PROMOTE.value),
+        ).fetchone()
+
+    @staticmethod
+    def _ledger_event_from_row(row: sqlite3.Row) -> LedgerEvent:
+        return LedgerEvent(
+            event_id=row["event_id"],
+            previous_hash=row["previous_hash"],
+            chain_sequence=int(row["chain_sequence"]),
+            event_type=row["event_type"],
+            recorded_at=row["recorded_at"],
+            actor_id=row["actor_id"],
+            object_id=row["object_id"],
+            object_type=row["object_type"],
+            root_id=row["root_id"],
+            payload=json.loads(row["payload_json"]),
+            target_object_id=row["target_object_id"],
+            parent_id=row["parent_id"],
+            candidate_id=row["candidate_id"],
+            policy_version=row["policy_version"],
+            reason=row["reason"],
+            metadata=json.loads(row["metadata_json"] or "{}"),
+        )
+
+    def get_promotion_event(self, candidate_id: str) -> LedgerEvent | None:
+        """Return the canonical promotion event claimed by a candidate."""
+        with self._connection() as conn:
+            row = self._promotion_event_row(conn, candidate_id)
+        return self._ledger_event_from_row(row) if row is not None else None
 
     def get_root_lineage(self, root_id: str) -> list[dict[str, Any]]:
         """All events for a given root, oldest first."""

--- a/atlas_core/trust/promotion_policy.py
+++ b/atlas_core/trust/promotion_policy.py
@@ -6,9 +6,9 @@ wiring. Four gates run in order; any failure blocks promotion:
   Gate 1 — Policy: candidate must satisfy quarantine auto_promote rules
   Gate 2 — Verification: corroboration must be >= verification floor
   Gate 3 — Hard-block: configurable safety predicates (defaults: deny-list)
-  Gate 4 — Ledger write: atomic — ledger event THEN candidate.promoted
+  Gate 4 — Ledger write: idempotent ledger event THEN candidate.promoted
 
-Phase 2 W4 ships the gate scaffolding + ledger-write atomicity. The hard-block
+Phase 2 W4 ships the gate scaffolding + recoverable ledger writes. The hard-block
 predicate registry is intentionally minimal in v1; production deployments
 extend via register_hard_block().
 
@@ -119,10 +119,10 @@ def _check_hard_blocks(candidate: dict) -> str | None:
 class PromotionPolicy:
     """Coordinates promotion from quarantine → ledger.
 
-    Wires the trust quarantine + hash-chained ledger into a single atomic
-    pipeline. Caller invokes promote(candidate_id); pipeline runs the
-    four gates and either promotes (writing both a ledger event and
-    updating the candidate row) or returns the gate failure.
+    Wires the trust quarantine + hash-chained ledger into a recoverable
+    pipeline. The stores are separate SQLite databases, so the ledger claims
+    one canonical promotion event per candidate and retries reuse that event
+    before updating the candidate row.
     """
 
     def __init__(
@@ -145,9 +145,9 @@ class PromotionPolicy:
     ) -> PromotionResult:
         """Run the 4-gate pipeline. Returns PromotionResult with gates list.
 
-        Atomic: either the ledger event AND the candidate row update both
-        succeed, or neither does (the ledger append is itself atomic via
-        BEGIN IMMEDIATE; candidate update follows).
+        Recoverable: if the candidate-row update fails after the ledger commit,
+        retrying reuses the candidate's canonical promotion event instead of
+        extending the chain again.
         """
         result = PromotionResult(candidate_id=candidate_id, promoted=False)
 
@@ -161,6 +161,24 @@ class PromotionPolicy:
             result.blocked_at_gate = "lookup"
             result.blocked_reason = "candidate not found"
             return result
+
+        if candidate["status"] == CandidateStatus.APPROVED.value:
+            existing_event = self.ledger.get_promotion_event(candidate_id)
+            if (
+                existing_event is not None
+                and candidate.get("ledger_event_id") == existing_event.event_id
+            ):
+                result.gates.append(GateResult(
+                    gate="ledger_write",
+                    outcome=GateOutcome.PASS,
+                    reason=(
+                        f"already promoted at chain_seq="
+                        f"{existing_event.chain_sequence}"
+                    ),
+                ))
+                result.promoted = True
+                result.ledger_event = existing_event
+                return result
 
         # Gate 1: Policy — candidate must be in auto_promoted state OR caller
         # is explicitly approving a requires_approval candidate.
@@ -187,7 +205,7 @@ class PromotionPolicy:
             result.blocked_reason = gate3.reason
             return result
 
-        # Gate 4: Ledger write — atomic event creation + candidate update
+        # Gate 4: idempotent ledger event + recoverable candidate update
         try:
             ledger_event = self._write_ledger_event(
                 candidate=candidate, actor_id=actor_id,

--- a/atlas_core/trust/quarantine.py
+++ b/atlas_core/trust/quarantine.py
@@ -498,7 +498,7 @@ class QuarantineStore:
         """
         now = _utc_now()
         with self._connection() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE candidates
                 SET status = ?, ledger_event_id = ?, decision_id = ?,
@@ -516,6 +516,8 @@ class QuarantineStore:
                     candidate_id,
                 ),
             )
+            if cursor.rowcount != 1:
+                raise KeyError(f"candidate {candidate_id!r} not found")
 
     def deny_candidate(
         self,

--- a/atlas_core/trust/schemas/ledger.schema.sql
+++ b/atlas_core/trust/schemas/ledger.schema.sql
@@ -8,9 +8,10 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS change_events (
     -- HASH CHAIN (Atlas-original; Bicameral lacks these fields)
-    event_id        TEXT PRIMARY KEY,        -- SHA-256(previous_hash + canonical_payload)
+    event_id        TEXT PRIMARY KEY,        -- Versioned SHA-256 event-envelope hash
     previous_hash   TEXT,                    -- NULL for genesis; SHA-256 of prior row's event_id
     chain_sequence  INTEGER NOT NULL UNIQUE, -- Monotonic; gap detection signal
+    hash_version    INTEGER NOT NULL DEFAULT 2,
 
     -- Event content (port from Bicameral)
     event_type      TEXT NOT NULL,           -- assert | supersede | invalidate |
@@ -41,6 +42,15 @@ CREATE INDEX IF NOT EXISTS idx_change_events_root      ON change_events(root_id,
 CREATE INDEX IF NOT EXISTS idx_change_events_object    ON change_events(object_id, recorded_at);
 CREATE INDEX IF NOT EXISTS idx_change_events_chain     ON change_events(chain_sequence);
 CREATE INDEX IF NOT EXISTS idx_change_events_candidate ON change_events(candidate_id);
+
+-- Cross-database promotion recovery. The candidate row lives in candidates.db,
+-- so this ledger-local claim makes one PROMOTE event per candidate idempotent
+-- even if the candidates.db update fails after the append commits.
+CREATE TABLE IF NOT EXISTS promotion_claims (
+    candidate_id TEXT PRIMARY KEY,
+    event_id     TEXT NOT NULL UNIQUE,
+    FOREIGN KEY (event_id) REFERENCES change_events(event_id)
+);
 
 -- Materialized view: current state per root lineage (port from Bicameral)
 CREATE TABLE IF NOT EXISTS typed_roots (

--- a/demo.sh
+++ b/demo.sh
@@ -126,7 +126,8 @@ async def main():
     # Wipe demo namespace
     async with driver.session() as s:
         await s.run(
-            "MATCH (n) WHERE n.kref STARTS WITH $p DETACH DELETE n",
+            "MATCH (n) WHERE n.kref STARTS WITH $p "
+            "OR n.root_kref STARTS WITH $p DETACH DELETE n",
             p=f"kref://{NS}/",
         )
 

--- a/docs/INSTALL_MODES.md
+++ b/docs/INSTALL_MODES.md
@@ -85,6 +85,10 @@ PYTHONPATH=. python -m atlas_core.daemon.cycle
 This walks the vault and quarantines new claims. Then run
 `python scripts/adjudicate.py --all` to promote eligible claims to the ledger
 and project every approved claim into Neo4j as a belief linked to its subject.
+That materialization step creates an immutable AGM revision and runs Ripple
+once for the approved ledger event; a retry records and reuses completion
+state instead of duplicating a cascade.
+Dependency edges are explicit graph state and are not inferred from prose.
 The adjudication queue appears as markdown files under
 `~/.atlas/adjudication/` — open that folder in Obsidian alongside your main
 vault, and resolved entries archive to `~/.atlas/adjudication/archive/`.

--- a/obsidian-plugin/README.md
+++ b/obsidian-plugin/README.md
@@ -33,6 +33,13 @@ cp main.js manifest.json ~/Obsidian/<your-vault>/.obsidian/plugins/atlas-memory/
 ```
 
 Then in Obsidian → Settings → Community plugins → enable "Atlas Memory."
+Open the plugin settings and paste the per-install token printed by:
+
+```bash
+cat ~/.atlas/http-token
+```
+
+The API requires this token for every route except `/health`.
 
 ## Distribution roadmap
 

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -22,12 +22,14 @@ const ATLAS_VIEW_TYPE = "atlas-adjudication-view";
 
 interface AtlasSettings {
   apiUrl: string;
+  apiToken: string;
   adjudicationDir: string;
   agentId: string;
 }
 
 const DEFAULT_SETTINGS: AtlasSettings = {
   apiUrl: "http://localhost:9879",
+  apiToken: "",
   adjudicationDir: "00 Atlas/adjudication",
   agentId: "rich",
 };
@@ -101,6 +103,13 @@ export default class AtlasMemoryPlugin extends Plugin {
       && file.extension === "md";
   }
 
+  apiHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${this.settings.apiToken}`,
+    };
+  }
+
   async handleAdjudicationSave(file: TFile) {
     const text = await this.app.vault.read(file);
     const proposalId = this.extractFrontmatterValue(text, "proposal_id");
@@ -118,7 +127,7 @@ export default class AtlasMemoryPlugin extends Plugin {
         `${this.settings.apiUrl}/tools/adjudication.resolve`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: this.apiHeaders(),
           body: JSON.stringify({
             params: {
               proposal_id: proposalId,
@@ -190,7 +199,7 @@ export default class AtlasMemoryPlugin extends Plugin {
         `${this.settings.apiUrl}/tools/adjudication.queue`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: this.apiHeaders(),
           body: JSON.stringify({ params: { limit: 50 } }),
         },
       );
@@ -275,6 +284,20 @@ class AtlasSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }),
       );
+
+    new Setting(containerEl)
+      .setName("Atlas API token")
+      .setDesc("Read from ~/.atlas/http-token on the machine running Atlas.")
+      .addText((text) => {
+        text.inputEl.type = "password";
+        return text
+          .setPlaceholder("Paste the local API token")
+          .setValue(this.plugin.settings.apiToken)
+          .onChange(async (value) => {
+            this.plugin.settings.apiToken = value.trim();
+            await this.plugin.saveSettings();
+          });
+      });
 
     new Setting(containerEl)
       .setName("Adjudication directory")

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -1,0 +1,639 @@
+{
+  "name": "atlas-memory-obsidian",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "atlas-memory-obsidian",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "esbuild": "^0.28.1",
+        "obsidian": "^1.5.0",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/obsidian": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+      "integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "esbuild": "^0.20.0",
+    "esbuild": "^0.28.1",
     "obsidian": "^1.5.0",
     "typescript": "^5.3.0"
   }

--- a/scripts/adjudicate.py
+++ b/scripts/adjudicate.py
@@ -265,10 +265,11 @@ def auto_deny(
 
 
 async def materialize_from_env(quarantine: QuarantineStore):
-    """Connect to configured Neo4j and retry every ledger-approved candidate."""
+    """Project approved candidates and finish their pending Ripple cascades."""
     from neo4j import AsyncGraphDatabase
 
     from atlas_core.ingestion import materialize_approved_candidates
+    from atlas_core.ripple.engine import RippleEngine
 
     driver = AsyncGraphDatabase.driver(
         os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
@@ -279,7 +280,11 @@ async def materialize_from_env(quarantine: QuarantineStore):
     )
     try:
         await driver.verify_connectivity()
-        return await materialize_approved_candidates(driver, quarantine)
+        return await materialize_approved_candidates(
+            driver,
+            quarantine,
+            ripple_engine=RippleEngine(driver),
+        )
     finally:
         await driver.close()
 
@@ -404,7 +409,7 @@ def main(argv: list[str] | None = None) -> int:
             grand.materialize_failed += 1
         else:
             grand.materialized += report.materialized
-            grand.materialize_failed += report.failed
+            grand.materialize_failed += report.failed + report.ripple_failed
             for error in report.errors:
                 print(f"materialization failed: {error}", file=sys.stderr)
 

--- a/scripts/demo_loop.py
+++ b/scripts/demo_loop.py
@@ -129,7 +129,8 @@ async def main() -> None:
     # Wipe any prior demo state
     async with driver.session() as session:
         await session.run(
-            "MATCH (n) WHERE n.kref STARTS WITH 'kref://demo/' DETACH DELETE n"
+            "MATCH (n) WHERE n.kref STARTS WITH 'kref://demo/' "
+            "OR n.root_kref STARTS WITH 'kref://demo/' DETACH DELETE n"
         )
 
     banner("ATLAS — open-source local-first cognitive memory")

--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -137,5 +137,6 @@ echo "  ~/.atlas/health/com.atlas.ingestion.jsonl"
 echo "  ~/.atlas/health/com.atlas.api-server.stdout.log"
 echo
 echo "API server: http://localhost:9879/health"
+echo "API token:  $HOME/.atlas/http-token"
 echo
 echo "To stop:  ./scripts/install_launchd.sh stop"

--- a/site/live-real.html
+++ b/site/live-real.html
@@ -164,6 +164,10 @@ or:           PYTHONPATH=. uvicorn atlas_core.api.api_app:app --port 9879
     <p style="margin-top:6px;font-size:11px;color:var(--muted)">
       Press Enter to reconnect.
     </p>
+    <input id="token-input" type="password" placeholder="~/.atlas/http-token" />
+    <p style="margin-top:6px;font-size:11px;color:var(--muted)">
+      Atlas API token. The server origin allowlist must include this page.
+    </p>
 
     <h3>Counters</h3>
     <div class="stat"><span class="num" id="ct-total">0</span><span class="label">total events</span></div>
@@ -185,8 +189,9 @@ or:           PYTHONPATH=. uvicorn atlas_core.api.api_app:app --port 9879
   const log = document.getElementById("log");
   const status = document.getElementById("status");
   const endpoint = document.getElementById("endpoint-input");
+  const tokenInput = document.getElementById("token-input");
 
-  let source = null;
+  let activeRequest = null;
 
   function setStatus(text, cls) {
     status.textContent = text;
@@ -197,11 +202,15 @@ or:           PYTHONPATH=. uvicorn atlas_core.api.api_app:app --port 9879
     const div = document.createElement("div");
     div.className = "ev " + eventData.kind;
     const tsShort = (eventData.occurred_at || "").slice(11, 19);
-    div.innerHTML = `
-      <span class="ts">${tsShort}</span>
-      <span class="kind">${eventData.kind}</span>
-      <pre>${JSON.stringify(eventData.payload, null, 2)}</pre>
-    `;
+    const timestamp = document.createElement("span");
+    timestamp.className = "ts";
+    timestamp.textContent = tsShort;
+    const kind = document.createElement("span");
+    kind.className = "kind";
+    kind.textContent = eventData.kind;
+    const payload = document.createElement("pre");
+    payload.textContent = JSON.stringify(eventData.payload, null, 2);
+    div.append(timestamp, kind, payload);
     log.insertBefore(div, log.firstChild);
     counters.total += 1;
     counters[eventData.kind] = (counters[eventData.kind] || 0) + 1;
@@ -211,23 +220,42 @@ or:           PYTHONPATH=. uvicorn atlas_core.api.api_app:app --port 9879
     document.getElementById("ct-ledger").textContent = counters.ledger_supersede || 0;
   }
 
-  function connect(url) {
-    if (source) source.close();
+  async function connect(url) {
+    if (activeRequest) activeRequest.abort();
+    activeRequest = new AbortController();
     setStatus("connecting", "");
     document.getElementById("endpoint").textContent = url;
     try {
-      source = new EventSource(url);
-      source.onopen = () => setStatus("live", "live");
-      source.onerror = () => setStatus("error — is the API server running?", "error");
-      source.onmessage = (e) => {
-        try {
-          const data = JSON.parse(e.data);
-          addEvent(data);
-        } catch (err) {
-          console.error("malformed event", err);
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${tokenInput.value.trim()}` },
+        signal: activeRequest.signal,
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setStatus("live", "live");
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const blocks = buffer.split(/\r?\n\r?\n/);
+        buffer = blocks.pop() || "";
+        for (const block of blocks) {
+          const dataLine = block.split(/\r?\n/).find((line) => line.startsWith("data: "));
+          if (!dataLine) continue;
+          try {
+            addEvent(JSON.parse(dataLine.slice(6)));
+          } catch (err) {
+            console.error("malformed event", err);
+          }
         }
-      };
+      }
+      setStatus("disconnected", "error");
     } catch (err) {
+      if (err.name === "AbortError") return;
       setStatus("error: " + err, "error");
     }
   }
@@ -235,8 +263,11 @@ or:           PYTHONPATH=. uvicorn atlas_core.api.api_app:app --port 9879
   endpoint.addEventListener("keydown", (e) => {
     if (e.key === "Enter") connect(endpoint.value.trim());
   });
+  tokenInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") connect(endpoint.value.trim());
+  });
 
-  connect(endpoint.value.trim());
+  setStatus("token required", "");
 </script>
 
 </body>

--- a/tests/integration/test_candidate_materialization.py
+++ b/tests/integration/test_candidate_materialization.py
@@ -28,8 +28,11 @@ async def driver():
         await drv.close()
 
 
-async def test_approved_candidate_materializes_once_with_about_edge(driver, tmp_path):
+async def test_approved_candidate_materializes_as_agm_revision_and_runs_ripple(
+    driver, tmp_path
+):
     from atlas_core.ingestion import materialize_approved_candidates
+    from atlas_core.ripple.engine import RippleEngine
     from atlas_core.trust import (
         CandidateClaim,
         EvidenceRef,
@@ -63,12 +66,31 @@ async def test_approved_candidate_materializes_once_with_about_edge(driver, tmp_
     assert promoted.promoted is True
     assert len(quarantine.list_approved()) == 1
 
+    class RecordingRipple:
+        def __init__(self):
+            self.engine = RippleEngine(driver, emit_events=False)
+            self.calls = []
+
+        async def propagate(self, upstream_kref, **kwargs):
+            result = await self.engine.propagate(upstream_kref, **kwargs)
+            self.calls.append((upstream_kref, kwargs, result))
+            return result
+
+    ripple = RecordingRipple()
+
     try:
-        first = await materialize_approved_candidates(driver, quarantine)
-        second = await materialize_approved_candidates(driver, quarantine)
+        first = await materialize_approved_candidates(
+            driver, quarantine, ripple_engine=ripple
+        )
+        second = await materialize_approved_candidates(
+            driver, quarantine, ripple_engine=ripple
+        )
         assert first.materialized == 1 and first.failed == 0
         assert second.materialized == 1 and second.failed == 0
         assert first.belief_krefs == second.belief_krefs
+        assert first.ripple_completed == 1
+        assert second.ripple_completed == 0
+        assert len(ripple.calls) == 1
 
         async with driver.session() as session:
             result = await session.run(
@@ -86,9 +108,71 @@ async def test_approved_candidate_materializes_once_with_about_edge(driver, tmp_
         assert row["edges"] == 1
         assert row["ledger_event_id"] == promoted.ledger_event.event_id
         assert row["object_value"] == "$3,495"
+
+        dependent_kref = f"kref://{project}/Decisions/pricing.decision"
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (belief:Belief {candidate_id: $cid}) "
+                "MERGE (dependent:AtlasItem:Belief {kref: $dependent_kref}) "
+                "SET dependent.confidence_score = 0.8, "
+                "dependent.hypothesis = 'keep the current offer', "
+                "dependent.deprecated = false, dependent.stakes = 'low', "
+                "dependent.is_core_conviction = false "
+                "MERGE (dependent)-[:DEPENDS_ON {dependency_strength: 1.0}]"
+                "->(belief)",
+                cid=upsert.candidate_id,
+                dependent_kref=dependent_kref,
+            )
+
+        revised_upsert = quarantine.upsert_candidate(CandidateClaim(
+            lane="atlas_vault",
+            assertion_type="factual_assertion",
+            subject_kref=subject_kref,
+            predicate="pricing_belief",
+            object_value="$3,995",
+            confidence=0.97,
+            evidence_ref=EvidenceRef(
+                source="test-revision",
+                source_family="vault",
+                kref=f"kref://{project}/Vault/pricing-revision.note",
+                timestamp="2026-07-17T00:00:00+00:00",
+            ),
+        ), auto_promote_enabled=False)
+        revised = PromotionPolicy(quarantine=quarantine, ledger=ledger).promote(
+            revised_upsert.candidate_id,
+            actor_id="test.materializer",
+        )
+        assert revised.promoted is True
+
+        ripple.calls.clear()
+        revision_report = await materialize_approved_candidates(
+            driver, quarantine, ripple_engine=ripple
+        )
+        assert revision_report.failed == 0
+        assert revision_report.ripple_completed == 1
+        assert len(ripple.calls) == 1
+        assert ripple.calls[0][0] == first.belief_krefs[0]
+        assert ripple.calls[0][2].n_impacted == 1
+
+        async with driver.session() as session:
+            result = await session.run(
+                "MATCH (b:Belief {candidate_id: $cid}) "
+                "MATCH (rev:AtlasRevision {root_kref: b.root_kref}) "
+                "OPTIONAL MATCH (:AtlasRevision {root_kref: b.root_kref})"
+                "-[s:SUPERSEDES]->(:AtlasRevision) "
+                "RETURN b.object_value AS object_value, "
+                "count(DISTINCT rev) AS revisions, count(DISTINCT s) AS supersedes",
+                cid=revised_upsert.candidate_id,
+            )
+            revision_row = await result.single()
+        assert revision_row is not None
+        assert revision_row["object_value"] == "$3,995"
+        assert revision_row["revisions"] == 2
+        assert revision_row["supersedes"] == 1
     finally:
         async with driver.session() as session:
             await session.run(
-                "MATCH (n) WHERE n.kref STARTS WITH $prefix DETACH DELETE n",
+                "MATCH (n) WHERE n.kref STARTS WITH $prefix "
+                "OR n.root_kref STARTS WITH $prefix DETACH DELETE n",
                 prefix=f"kref://{project}/",
             )

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -9,6 +9,8 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
+HTTP_TOKEN = "integration-test-token-with-at-least-32-characters"
+
 
 @pytest.fixture(scope="module")
 def neo4j_uri() -> str:
@@ -53,7 +55,7 @@ def http_app(driver, tmp_dir):
     quarantine = QuarantineStore(tmp_dir / "candidates.db")
     ledger = HashChainedLedger(tmp_dir / "ledger.db")
     server = AtlasMCPServer(driver=driver, quarantine=quarantine, ledger=ledger)
-    return create_http_app(mcp_server=server)
+    return create_http_app(mcp_server=server, bearer_token=HTTP_TOKEN)
 
 
 @pytest.fixture
@@ -61,7 +63,11 @@ async def client(http_app):
     from httpx import ASGITransport, AsyncClient
 
     transport = ASGITransport(app=http_app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {HTTP_TOKEN}"},
+    ) as c:
         yield c
 
 

--- a/tests/integration/test_schema_constraints.py
+++ b/tests/integration/test_schema_constraints.py
@@ -130,3 +130,46 @@ async def test_duplicate_kref_rejected_after_ensure_schema(driver, ns):
         assert await _count(driver, ns) == 1, "duplicate must not have been created"
     finally:
         await _delete_ns(driver, ns)
+
+
+async def test_agm_revise_reuses_existing_kref_root_after_constraints(driver, ns):
+    """AGM revision must attach to a live belief, not create a duplicate root."""
+    from atlas_core.migrations.schema import ensure_schema
+    from atlas_core.revision.agm import revise
+    from atlas_core.revision.uri import Kref
+
+    await ensure_schema(driver)
+    async with driver.session() as session:
+        await session.run(
+            "MATCH (n) WHERE n.kref = $k OR n.root_kref = $k DETACH DELETE n",
+            k=ns,
+        )
+        await session.run(
+            "CREATE (:AtlasItem:Belief {kref: $k, confidence_score: 0.8})",
+            k=ns,
+        )
+    try:
+        await revise(
+            driver,
+            Kref.parse(ns),
+            {"confidence": 0.7},
+            revision_reason="schema identity regression",
+        )
+        async with driver.session() as session:
+            result = await session.run(
+                "MATCH (n:AtlasItem) "
+                "WHERE n.kref = $k OR n.root_kref = $k "
+                "RETURN count(n) AS roots, "
+                "collect(n.root_kref) AS root_krefs",
+                k=ns,
+            )
+            record = await result.single()
+        assert int(record["roots"]) == 1
+        assert record["root_krefs"] == [ns]
+    finally:
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (n) WHERE n.kref = $k OR n.root_kref = $k "
+                "DETACH DELETE n",
+                k=ns,
+            )

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -14,7 +14,37 @@ def test_token_is_created_owner_only_and_reused(tmp_path, monkeypatch):
 
     assert len(first) >= 32
     assert second == first
-    assert (tmp_path / "http-token").stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert (tmp_path / "http-token").stat().st_mode & 0o777 == 0o600
+
+
+def test_windows_acl_removes_inheritance_and_grants_current_user(
+    tmp_path, monkeypatch
+):
+    from atlas_core.api import auth
+
+    token_path = tmp_path / "http-token"
+    token_path.write_text("x" * 40, encoding="utf-8")
+    monkeypatch.setenv("USERNAME", "atlas-user")
+    monkeypatch.setenv("USERDOMAIN", "ATLAS-PC")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+
+    monkeypatch.setattr(auth.subprocess, "run", fake_run)
+    auth._secure_windows_token_file(token_path)
+
+    assert calls == [(
+        [
+            "icacls",
+            str(token_path),
+            "/inheritance:r",
+            "/grant:r",
+            "ATLAS-PC\\atlas-user:(F)",
+        ],
+        {"check": True, "capture_output": True, "text": True},
+    )]
 
 
 def test_environment_token_takes_precedence(tmp_path, monkeypatch):

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -1,0 +1,49 @@
+"""Per-install HTTP token lifecycle tests."""
+
+import os
+
+import pytest
+
+
+def test_token_is_created_owner_only_and_reused(tmp_path, monkeypatch):
+    from atlas_core.api.auth import load_or_create_http_token
+
+    monkeypatch.delenv("ATLAS_HTTP_TOKEN", raising=False)
+    first = load_or_create_http_token(tmp_path)
+    second = load_or_create_http_token(tmp_path)
+
+    assert len(first) >= 32
+    assert second == first
+    assert (tmp_path / "http-token").stat().st_mode & 0o777 == 0o600
+
+
+def test_environment_token_takes_precedence(tmp_path, monkeypatch):
+    from atlas_core.api.auth import load_or_create_http_token
+
+    configured = "configured-token-with-at-least-32-characters"
+    monkeypatch.setenv("ATLAS_HTTP_TOKEN", configured)
+
+    assert load_or_create_http_token(tmp_path) == configured
+    assert not (tmp_path / "http-token").exists()
+
+
+def test_short_environment_token_is_rejected(tmp_path, monkeypatch):
+    from atlas_core.api.auth import load_or_create_http_token
+
+    monkeypatch.setenv("ATLAS_HTTP_TOKEN", "too-short")
+
+    with pytest.raises(ValueError, match="at least 32"):
+        load_or_create_http_token(tmp_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="platform lacks O_NOFOLLOW")
+def test_symlink_token_is_rejected(tmp_path, monkeypatch):
+    from atlas_core.api.auth import load_or_create_http_token
+
+    monkeypatch.delenv("ATLAS_HTTP_TOKEN", raising=False)
+    target = tmp_path / "target"
+    target.write_text("x" * 40, encoding="utf-8")
+    (tmp_path / "http-token").symlink_to(target)
+
+    with pytest.raises(OSError):
+        load_or_create_http_token(tmp_path)

--- a/tests/unit/test_graphiti_ripple_boundary.py
+++ b/tests/unit/test_graphiti_ripple_boundary.py
@@ -1,0 +1,46 @@
+"""Raw Graphiti extraction must not bypass the trust materialization boundary."""
+
+from types import SimpleNamespace
+
+
+async def test_raw_graphiti_ingestion_does_not_call_ripple(monkeypatch):
+    from graphiti_core import Graphiti
+
+    from atlas_core.graphiti import AtlasGraphiti
+
+    results = SimpleNamespace(
+        edges=[SimpleNamespace(uuid="edge-1", expired_at=None)],
+        episode=SimpleNamespace(uuid="episode-1"),
+    )
+
+    async def fake_add_episode(_self, *_args, **_kwargs):
+        return results
+
+    class Ledger:
+        @staticmethod
+        def is_promoted(_edge_uuid):
+            return True
+
+    class StrictRippleEngine:
+        def __init__(self):
+            self.calls = []
+
+        async def propagate(
+            self,
+            upstream_kref,
+            *,
+            old_confidence,
+            new_confidence,
+            belief_text="",
+        ):
+            self.calls.append(upstream_kref)
+
+    monkeypatch.setattr(Graphiti, "add_episode", fake_add_episode)
+    atlas = object.__new__(AtlasGraphiti)
+    atlas.ripple_engine = StrictRippleEngine()
+    atlas.ledger = Ledger()
+
+    returned = await atlas.add_episode()
+
+    assert returned is results
+    assert atlas.ripple_engine.calls == []

--- a/tests/unit/test_http_server_security.py
+++ b/tests/unit/test_http_server_security.py
@@ -1,0 +1,112 @@
+"""Security boundary tests for the localhost FastAPI surface."""
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass
+class _DispatchResult:
+    ok: bool = True
+    result: dict | None = None
+    error: str | None = None
+
+
+class _FakeMCPServer:
+    def __init__(self):
+        self.dispatched: list[tuple[str, dict]] = []
+
+    def list_tools(self):
+        return [{"name": "memory.forget"}]
+
+    async def dispatch(self, name, params):
+        self.dispatched.append((name, params))
+        return _DispatchResult(result={"name": name})
+
+
+@pytest.fixture
+def fake_server():
+    return _FakeMCPServer()
+
+
+@pytest.fixture
+def http_app(fake_server):
+    from atlas_core.api import create_http_app
+
+    return create_http_app(
+        mcp_server=fake_server,
+        bearer_token="test-token-that-is-long-enough-for-local-auth",
+        allowed_origins=["app://obsidian.md"],
+    )
+
+
+@pytest.fixture
+async def client(http_app):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://test"
+    ) as value:
+        yield value
+
+
+def _auth_headers():
+    return {"Authorization": "Bearer test-token-that-is-long-enough-for-local-auth"}
+
+
+async def test_health_is_the_only_anonymous_route(client):
+    assert (await client.get("/health")).status_code == 200
+    assert (await client.get("/tools")).status_code == 401
+    assert (await client.get("/verify-chain")).status_code == 401
+    assert (await client.get("/events/stats")).status_code == 401
+
+
+async def test_authorized_dispatch_reaches_mcp_server(client, fake_server):
+    response = await client.post(
+        "/tools/memory.forget",
+        headers=_auth_headers(),
+        json={"params": {"memory_id": "m-1"}},
+    )
+
+    assert response.status_code == 200
+    assert fake_server.dispatched == [
+        ("memory.forget", {"memory_id": "m-1"})
+    ]
+
+
+async def test_unauthorized_dispatch_never_reaches_mcp_server(client, fake_server):
+    response = await client.post(
+        "/tools/memory.forget",
+        json={"params": {"memory_id": "m-1"}},
+    )
+
+    assert response.status_code == 401
+    assert fake_server.dispatched == []
+
+
+async def test_cors_rejects_untrusted_web_origins(client):
+    response = await client.options(
+        "/tools/memory.forget",
+        headers={
+            "Origin": "https://attacker.example",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+async def test_cors_allows_configured_obsidian_origin(client):
+    response = await client.options(
+        "/tools/memory.forget",
+        headers={
+            "Origin": "app://obsidian.md",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "app://obsidian.md"

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -65,7 +65,7 @@ class TestGenesisEvent:
 
     def test_genesis_event_id_is_deterministic(self, tmp_ledger):
         """Recompute event_id and verify it matches stored value."""
-        from atlas_core.trust.ledger import EventType, _compute_event_id
+        from atlas_core.trust.ledger import EventType, _compute_event_id_v2
 
         ev = tmp_ledger.append_event(
             event_type=EventType.ASSERT,
@@ -79,12 +79,22 @@ class TestGenesisEvent:
         # Manually recompute
         import json
         canonical_payload = json.dumps({"a": 1}, sort_keys=True, separators=(",", ":"))
-        recomputed = _compute_event_id(
+        recomputed = _compute_event_id_v2(
             previous_hash=None,
+            chain_sequence=1,
             event_type="assert",
             recorded_at=ev.recorded_at,
+            actor_id="atlas",
+            reason=None,
             object_id="kref://test/Beliefs/x.belief?r=1",
+            target_object_id=None,
+            object_type="StrategicBelief",
+            root_id="kref://test/Beliefs/x.belief",
+            parent_id=None,
+            candidate_id=None,
+            policy_version=None,
             payload_json=canonical_payload,
+            metadata_json="{}",
         )
         assert recomputed == ev.event_id
 
@@ -166,6 +176,36 @@ class TestVerifyChain:
         result = tmp_ledger.verify_chain()
         assert result.intact is True
         assert result.last_verified_sequence == 1
+
+    def test_legacy_v1_event_remains_verifiable(self, tmp_ledger):
+        """The v2 verifier preserves chains written before full-envelope hashes."""
+        from atlas_core.trust.ledger import EventType, _compute_event_id
+
+        event = tmp_ledger.append_event(
+            event_type=EventType.ASSERT,
+            actor_id="atlas",
+            object_id="kref://test/x.belief?r=1",
+            object_type="StrategicBelief",
+            root_id="kref://test/x.belief",
+            payload={"v": 1},
+        )
+        legacy_id = _compute_event_id(
+            previous_hash=None,
+            event_type="assert",
+            recorded_at=event.recorded_at,
+            object_id=event.object_id,
+            payload_json='{"v":1}',
+        )
+        with tmp_ledger._connection() as conn:
+            conn.execute(
+                "UPDATE change_events SET event_id = ?, hash_version = 1 "
+                "WHERE chain_sequence = 1",
+                (legacy_id,),
+            )
+
+        result = tmp_ledger.verify_chain()
+        assert result.intact is True
+        assert result.last_verified_event_id == legacy_id
 
     def test_three_event_chain_intact(self, tmp_ledger):
         from atlas_core.trust.ledger import EventType
@@ -356,6 +396,40 @@ class TestTypedRootsMaterializedView:
 
 
 class TestReadAPI:
+    def test_duplicate_promotion_backfill_uses_latest_legacy_event(self, tmp_ledger):
+        """Legacy retries may contain duplicates; the latest one was committed."""
+        from atlas_core.trust.ledger import EventType, HashChainedLedger
+
+        first = tmp_ledger.append_event(
+            event_type=EventType.PROMOTE,
+            actor_id="atlas",
+            object_id="kref://test/x.belief",
+            object_type="StrategicBelief",
+            root_id="kref://test/x.belief",
+            payload={"v": 1},
+            candidate_id="candidate-legacy",
+        )
+        with tmp_ledger._connection() as conn:
+            conn.execute("DELETE FROM promotion_claims")
+        second = tmp_ledger.append_event(
+            event_type=EventType.PROMOTE,
+            actor_id="atlas",
+            object_id="kref://test/x.belief",
+            object_type="StrategicBelief",
+            root_id="kref://test/x.belief",
+            payload={"v": 1},
+            candidate_id="candidate-legacy",
+        )
+        assert first.event_id != second.event_id
+        with tmp_ledger._connection() as conn:
+            conn.execute("DELETE FROM promotion_claims")
+
+        reopened = HashChainedLedger(tmp_ledger.db_path)
+        canonical = reopened.get_promotion_event("candidate-legacy")
+
+        assert canonical is not None
+        assert canonical.event_id == second.event_id
+
     def test_get_event_by_id(self, tmp_ledger):
         from atlas_core.trust.ledger import EventType
 

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -261,6 +261,43 @@ class TestVerifyChain:
         assert result.intact is False
         assert result.broken_at_sequence == 2
 
+    @pytest.mark.parametrize(
+        ("column", "tampered_value"),
+        [
+            ("actor_id", "mallory"),
+            ("reason", "rewritten after approval"),
+            ("metadata_json", '{"reviewed":false}'),
+        ],
+    )
+    def test_tamper_detection_covers_audit_fields(
+        self, tmp_ledger, column, tampered_value
+    ):
+        """Audit context is part of the event, so it must be hash-bound."""
+        from atlas_core.trust.ledger import EventType
+
+        tmp_ledger.append_event(
+            event_type=EventType.PROMOTE,
+            actor_id="reviewer",
+            object_id="kref://test/x.belief?r=1",
+            object_type="StrategicBelief",
+            root_id="kref://test/x.belief",
+            payload={"v": 1},
+            candidate_id="candidate-1",
+            policy_version="v1",
+            reason="approved after review",
+            metadata={"reviewed": True},
+        )
+        with tmp_ledger._connection() as conn:
+            conn.execute(
+                f"UPDATE change_events SET {column} = ? WHERE chain_sequence = 1",
+                (tampered_value,),
+            )
+
+        result = tmp_ledger.verify_chain()
+        assert result.intact is False
+        assert result.broken_at_sequence == 1
+        assert "event_id mismatch" in (result.breakage_reason or "")
+
 
 # ─── typed_roots materialized view ───────────────────────────────────────────
 

--- a/tests/unit/test_materializer_ripple.py
+++ b/tests/unit/test_materializer_ripple.py
@@ -1,0 +1,110 @@
+"""The supported trust materializer owns the post-promotion Ripple hook."""
+
+from types import SimpleNamespace
+
+
+class _FakeResult:
+    def __init__(self, record=None):
+        self.record = record
+
+    async def single(self):
+        return self.record
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.confidence = None
+        self.ripple_ledger_event_id = None
+
+    def session(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def run(self, query, **params):
+        if "SET belief.ripple_ledger_event_id" in query:
+            self.ripple_ledger_event_id = params["ledger_event_id"]
+            return _FakeResult()
+
+        previous_confidence = self.confidence
+        self.confidence = params["confidence"]
+        return _FakeResult({
+            "belief_kref": params["belief_kref"],
+            "previous_confidence": previous_confidence,
+            "ripple_ledger_event_id": self.ripple_ledger_event_id,
+        })
+
+
+class _FakeQuarantine:
+    def __init__(self, candidate):
+        self.candidate = candidate
+
+    def list_approved(self):
+        return [self.candidate]
+
+
+class _StrictRippleEngine:
+    def __init__(self):
+        self.calls = []
+
+    async def propagate(
+        self,
+        upstream_kref,
+        *,
+        old_confidence,
+        new_confidence,
+        belief_text="",
+    ):
+        self.calls.append({
+            "upstream_kref": upstream_kref,
+            "old_confidence": old_confidence,
+            "new_confidence": new_confidence,
+            "belief_text": belief_text,
+        })
+        return SimpleNamespace(succeeded=True)
+
+
+async def test_materialization_triggers_ripple_once_with_current_signature():
+    from atlas_core.ingestion import materialize_approved_candidates
+
+    candidate = {
+        "candidate_id": "candidate-1",
+        "status": "approved",
+        "ledger_event_id": "ledger-event-1",
+        "subject_kref": "kref://test/People/rich.person",
+        "predicate": "pref.theme",
+        "object_value": "dark",
+        "assertion_type": "preference",
+        "confidence": 0.95,
+        "trust_score": 1.0,
+        "scope": "global",
+        "lane": "atlas_vault",
+        "evidence_refs_json": "[]",
+    }
+    driver = _FakeDriver()
+    quarantine = _FakeQuarantine(candidate)
+    ripple = _StrictRippleEngine()
+
+    first = await materialize_approved_candidates(
+        driver, quarantine, ripple_engine=ripple
+    )
+    second = await materialize_approved_candidates(
+        driver, quarantine, ripple_engine=ripple
+    )
+
+    assert first.materialized == 1
+    assert first.ripple_completed == 1
+    assert second.materialized == 1
+    assert second.ripple_completed == 0
+    assert ripple.calls == [{
+        "upstream_kref": (
+            "kref://test/IngestedBeliefs/candidate_candidate-1.belief"
+        ),
+        "old_confidence": 0.0,
+        "new_confidence": 0.95,
+        "belief_text": "pref.theme: dark",
+    }]

--- a/tests/unit/test_materializer_ripple.py
+++ b/tests/unit/test_materializer_ripple.py
@@ -13,7 +13,9 @@ class _FakeResult:
 
 class _FakeDriver:
     def __init__(self):
-        self.confidence = None
+        self.revisions = {}
+        self.current_revision = None
+        self.current_content_json = None
         self.ripple_ledger_event_id = None
 
     def session(self):
@@ -30,13 +32,33 @@ class _FakeDriver:
             self.ripple_ledger_event_id = params["ledger_event_id"]
             return _FakeResult()
 
-        previous_confidence = self.confidence
-        self.confidence = params["confidence"]
-        return _FakeResult({
-            "belief_kref": params["belief_kref"],
-            "previous_confidence": previous_confidence,
-            "ripple_ledger_event_id": self.ripple_ledger_event_id,
-        })
+        if "existing_revision_kref" in query:
+            existing = self.revisions.get(params["ledger_event_id"])
+            return _FakeResult({
+                "existing_revision_kref": existing["revision_kref"] if existing else None,
+                "existing_previous_confidence": (
+                    existing["previous_confidence"] if existing else None
+                ),
+                "prior_content_json": None,
+                "current_revision_kref": self.current_revision,
+                "current_content_json": self.current_content_json,
+                "ripple_ledger_event_id": self.ripple_ledger_event_id,
+            })
+
+        if "RETURN belief.kref AS belief_kref" in query:
+            import json
+
+            self.revisions[params["ledger_event_id"]] = {
+                "revision_kref": params["revision_kref"],
+                "previous_confidence": params["previous_confidence"],
+            }
+            self.current_revision = params["revision_kref"]
+            self.current_content_json = json.dumps({
+                "confidence": params["confidence"],
+            })
+            return _FakeResult({"belief_kref": params["belief_kref"]})
+
+        raise AssertionError(f"unexpected Cypher: {query}")
 
 
 class _FakeQuarantine:
@@ -68,8 +90,11 @@ class _StrictRippleEngine:
         return SimpleNamespace(succeeded=True)
 
 
-async def test_materialization_triggers_ripple_once_with_current_signature():
-    from atlas_core.ingestion import materialize_approved_candidates
+async def test_materialization_triggers_ripple_once_with_current_signature(monkeypatch):
+    from atlas_core.ingestion import (
+        belief_kref_for_candidate,
+        materialize_approved_candidates,
+    )
 
     candidate = {
         "candidate_id": "candidate-1",
@@ -89,6 +114,16 @@ async def test_materialization_triggers_ripple_once_with_current_signature():
     quarantine = _FakeQuarantine(candidate)
     ripple = _StrictRippleEngine()
 
+    async def fake_revise(_driver, target_kref, _content, **_kwargs):
+        return SimpleNamespace(
+            new_revision_kref=target_kref.with_revision("revision-1")
+        )
+
+    monkeypatch.setattr(
+        "atlas_core.ingestion.materializer.revise",
+        fake_revise,
+    )
+
     first = await materialize_approved_candidates(
         driver, quarantine, ripple_engine=ripple
     )
@@ -101,10 +136,24 @@ async def test_materialization_triggers_ripple_once_with_current_signature():
     assert second.materialized == 1
     assert second.ripple_completed == 0
     assert ripple.calls == [{
-        "upstream_kref": (
-            "kref://test/IngestedBeliefs/candidate_candidate-1.belief"
-        ),
+        "upstream_kref": belief_kref_for_candidate(candidate),
         "old_confidence": 0.0,
         "new_confidence": 0.95,
         "belief_text": "pref.theme: dark",
     }]
+
+
+def test_belief_identity_is_stable_across_value_revisions():
+    from atlas_core.ingestion import belief_kref_for_candidate
+
+    base = {
+        "subject_kref": "kref://test/People/rich.person",
+        "predicate": "pref.theme",
+        "scope": "global",
+        "object_value": "dark",
+    }
+    changed_value = {**base, "object_value": "light"}
+    changed_predicate = {**base, "predicate": "pref.font"}
+
+    assert belief_kref_for_candidate(base) == belief_kref_for_candidate(changed_value)
+    assert belief_kref_for_candidate(base) != belief_kref_for_candidate(changed_predicate)

--- a/tests/unit/test_promotion_policy.py
+++ b/tests/unit/test_promotion_policy.py
@@ -206,6 +206,38 @@ class TestGate4LedgerWrite:
         # Ledger has no events
         assert ledger.chain_length() == 0
 
+    def test_retry_after_candidate_update_failure_reuses_ledger_event(
+        self, quarantine, ledger, policy, monkeypatch
+    ):
+        """A recoverable cross-database failure must not duplicate promotion."""
+        from atlas_core.trust import CandidateStatus
+
+        upsert = quarantine.upsert_candidate(make_claim())
+        original_promote = quarantine.promote_candidate
+        attempts = 0
+
+        def fail_once(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("simulated candidates.db write failure")
+            return original_promote(*args, **kwargs)
+
+        monkeypatch.setattr(quarantine, "promote_candidate", fail_once)
+
+        first = policy.promote(upsert.candidate_id)
+        assert first.promoted is False
+        assert ledger.chain_length() == 1
+
+        second = policy.promote(upsert.candidate_id)
+        assert second.promoted is True
+        assert ledger.chain_length() == 1
+        assert second.ledger_event.event_id == ledger.latest_event()["event_id"]
+
+        candidate = quarantine.get_candidate(upsert.candidate_id)
+        assert candidate["status"] == CandidateStatus.APPROVED.value
+        assert candidate["ledger_event_id"] == second.ledger_event.event_id
+
 
 # ─── End-to-end ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Pull Request

## What this PR does

Repairs the architecture boundaries identified in the Atlas audit and reconciles them with the fork-hardening work already merged in PR #35:

- ledger-approved claims materialize as immutable AGM revisions;
- Ripple runs through the supported trust-promotion path once per ledger event;
- raw Graphiti extraction can no longer bypass the trust boundary;
- the localhost FastAPI surface requires a per-install bearer token and explicit CORS origins;
- new ledger events hash-bind every semantic and audit field while legacy v1 chains remain verifiable;
- cross-database promotion retries reuse one canonical ledger event;
- AGM revision reuses the live belief root under Neo4j uniqueness constraints;
- the Obsidian plugin now has a locked, vulnerability-free, CI-verified production build.

## Identity and recovery contracts

- Belief identity is stable across value changes: subject + predicate + scope.
- Every approved value becomes an immutable AGM revision.
- Declared dependencies remain attached to the stable belief root.
- Graph projection and Ripple are recoverable, at-least-once operations.
- A completed cascade is recorded by ledger event so ordinary retries do not duplicate it.
- The candidate and ledger databases remain independently recoverable through one canonical promotion claim.

## Verification

- [x] Current `master` merged without rewriting contributor history
- [x] Full live-Neo4j suite: **695 passed**
- [x] AGM compliance: **49/49 scenarios**
- [x] BusinessMemBench: **1.000** (gate >= 0.90)
- [x] Real `demo.sh` seven-stage loop: strategic route, accepted resolution, `LOOP CLOSED`
- [x] Focused security/ledger/materializer suite: **52 passed**
- [x] AGM/schema/adjudication regression slice: **19 passed**
- [x] `ruff`, `compileall`, workflow YAML, shell syntax, JavaScript syntax, and `git diff --check`
- [x] Fresh wheel and sdist build; wheel installed; `atlas --help` executed
- [x] Obsidian plugin: locked `npm ci`, zero audit vulnerabilities, production bundle built
- [x] GitHub protected checks required before merge

## Security behavior

- `/health` remains anonymous for launchd probes.
- Every data, event, and mutation route requires the bearer token stored with mode `0600` at `~/.atlas/http-token`, unless `ATLAS_HTTP_TOKEN` is explicitly supplied.
- Wildcard CORS is rejected.
- The ledger is described accurately as hash-chained integrity detection, not as protection against a local writer who can rewrite and recompute the entire database.

## Reviewer note

The branch includes a merge from current upstream `master` to preserve Joe Cervino's original commits and attribution. The single code conflict was resolved by combining PR #35's schema installation with this PR's AGM/Ripple materialization path.
