### PR TITLE
Port tested hardening and CLI improvements from Tony fork

### DIFF
--- a/.github/workflows/cognitive-service.yml
+++ b/.github/workflows/cognitive-service.yml
@@ -2,20 +2,8 @@ name: Cognitive service conformance
 
 on:
   pull_request:
-    paths:
-      - "integrations/cognitive-service/**"
-      - "integrations/hermes-atlas/**"
-      - "tests/service/**"
-      - "tests/hermes/**"
-      - ".github/workflows/cognitive-service.yml"
   push:
     branches: [master]
-    paths:
-      - "integrations/cognitive-service/**"
-      - "integrations/hermes-atlas/**"
-      - "tests/service/**"
-      - "tests/hermes/**"
-      - ".github/workflows/cognitive-service.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/gbrain-native.yml
+++ b/.github/workflows/gbrain-native.yml
@@ -2,18 +2,8 @@ name: GBrain native bridge
 
 on:
   pull_request:
-    paths:
-      - "integrations/gbrain-atlas/**"
-      - "integrations/openclaw-atlas/src/cognitive-client.ts"
-      - "integrations/cognitive-service/**"
-      - ".github/workflows/gbrain-native.yml"
   push:
     branches: [master]
-    paths:
-      - "integrations/gbrain-atlas/**"
-      - "integrations/openclaw-atlas/src/cognitive-client.ts"
-      - "integrations/cognitive-service/**"
-      - ".github/workflows/gbrain-native.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/hermes-native.yml
+++ b/.github/workflows/hermes-native.yml
@@ -2,18 +2,8 @@ name: Hermes native provider
 
 on:
   pull_request:
-    paths:
-      - "integrations/hermes-atlas/**"
-      - "integrations/cognitive-service/**"
-      - "tests/hermes/**"
-      - ".github/workflows/hermes-native.yml"
   push:
     branches: [master]
-    paths:
-      - "integrations/hermes-atlas/**"
-      - "integrations/cognitive-service/**"
-      - "tests/hermes/**"
-      - ".github/workflows/hermes-native.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/openclaw-native.yml
+++ b/.github/workflows/openclaw-native.yml
@@ -2,16 +2,8 @@ name: OpenClaw native plugin
 
 on:
   pull_request:
-    paths:
-      - "integrations/openclaw-atlas/**"
-      - "integrations/cognitive-service/**"
-      - ".github/workflows/openclaw-native.yml"
   push:
     branches: [master]
-    paths:
-      - "integrations/openclaw-atlas/**"
-      - "integrations/cognitive-service/**"
-      - ".github/workflows/openclaw-native.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,3 +124,73 @@ jobs:
           name: bmb-matrix-py${{ matrix.python-version }}
           path: /tmp/bmb_ci.json
           if-no-files-found: warn
+
+  demo-smoke:
+    # The front door (demo.sh) is the "works today" proof Rich shows people.
+    # Run it end-to-end in CI against the Neo4j service container so it can
+    # never silently rot. The job fails if demo.sh exits non-zero OR if the
+    # loop does not close.
+    name: demo.sh smoke (front-door end-to-end)
+    runs-on: ubuntu-latest
+
+    services:
+      neo4j:
+        image: neo4j:5.26
+        env:
+          NEO4J_AUTH: neo4j/atlasdev
+          NEO4J_PLUGINS: '["apoc"]'
+          NEO4J_dbms_security_procedures_unrestricted: 'apoc.*'
+          NEO4J_apoc_export_file_enabled: 'true'
+          NEO4J_apoc_import_file_enabled: 'true'
+        ports:
+          - 7474:7474
+          - 7687:7687
+        options: >-
+          --health-cmd "wget --spider http://localhost:7474 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          allow-prereleases: true
+
+      - name: Wait for Neo4j to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -sf http://localhost:7474 > /dev/null; then
+              echo "Neo4j up"; exit 0
+            fi
+            sleep 2
+          done
+          echo "Neo4j never came up"
+          exit 1
+
+      - name: Build the repo-root .venv demo.sh expects
+        # demo.sh hard-requires a repo-root .venv and runs .venv/bin/python.
+        # Create it here so we exercise the real, unmodified front door.
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -e .[dev]
+
+      - name: Run demo.sh end-to-end (must exit 0 and close the loop)
+        env:
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USER: neo4j
+          NEO4J_PASSWORD: atlasdev
+          PYTHONPATH: .
+        run: |
+          set -euo pipefail
+          # demo.sh has `set -euo pipefail` and exits non-zero on any failure
+          # (missing prereqs, cascade failure -> sys.exit(2), etc.); pipefail
+          # propagates that through the tee.
+          ./demo.sh | tee demo_output.log
+          # Guard against a silent partial pass: the loop MUST close.
+          grep -q "LOOP CLOSED" demo_output.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,5 +192,8 @@ jobs:
           # (missing prereqs, cascade failure -> sys.exit(2), etc.); pipefail
           # propagates that through the tee.
           ./demo.sh | tee demo_output.log
-          # Guard against a silent partial pass: the loop MUST close.
+          # Guard against a narrated partial pass: one real proposal must
+          # route to review, resolve, and close the loop.
+          grep -q "strategic: 1" demo_output.log
+          grep -q "resolved with decision='accept'" demo_output.log
           grep -q "LOOP CLOSED" demo_output.log

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ The final stages of `./demo.sh` should look like this — if they don't, file an
   ✓ cascade complete
   impacted nodes: 2
   contradictions: 0
-  routing — auto: 2, strategic: 0, core: 0
+  routing — auto: 1, strategic: 1, core: 0
 
 ▶ Stage 5 / 7 — Reassessment proposals
   1. kref://AtlasDemo/Beliefs/origins_accessible.belief
-     0.88 → 0.74  (-0.14)
+     0.88 → 0.75  (-0.13)
   2. kref://AtlasDemo/Decisions/marketing_to_newcomers.decision
      0.80 → 0.66  (-0.14)
 
@@ -63,6 +63,20 @@ LOOP CLOSED.
 ```
 
 `last_verified_sequence = 1` looks small because the demo plants exactly one promotion-eligible fact and verifies the chain holds with one entry — every later run extends the chain and the number grows. The point is the chain *intact*, not the count.
+
+The installed Python package also exposes an `atlas` command:
+
+```bash
+atlas --help
+atlas status
+atlas queue --json
+atlas search "current pricing belief"
+atlas ingest
+```
+
+`atlas demo` delegates to the complete repository `demo.sh`, so that one
+command requires a source checkout. The operational commands work from an
+installed package.
 
 ### What Atlas is not
 
@@ -95,7 +109,7 @@ contracts and require no Neo4j or Docker for retrieval or the bounded
 AGM/Ripple service.
 
 Hermes, OpenClaw, and GBrain now share one proven cognitive boundary: their native packages
-manages a profile-scoped, authenticated localhost service that owns AGM
+manage a profile-scoped, authenticated localhost service that owns AGM
 revision, dependency traversal, and persisted Ripple proposals. Cognitive
 records participate in recall, search, list, get, forget, audit, and restart.
 The service uses SQLite for persistence but keeps cognitive semantics in one

--- a/atlas_core/cli.py
+++ b/atlas_core/cli.py
@@ -16,7 +16,7 @@ Subcommands:
                            (atlas_core.daemon.health.HealthLogger.latest)
   atlas ingest           — run one ingestion cycle
                            (atlas_core.daemon.cycle.run_ingestion_cycle)
-  atlas demo             — run the end-to-end demo (delegates to demo.sh)
+  atlas demo             — run the source-checkout demo (delegates to demo.sh)
 
 Registered as the `atlas` console script in pyproject.toml.
 """
@@ -249,7 +249,10 @@ def build_parser() -> argparse.ArgumentParser:
     # demo passes any extra flags (e.g. --quiet, --reset) straight through to
     # demo.sh. Those are collected as unrecognized args in main() rather than
     # declared here, so leading-dash flags aren't intercepted by this parser.
-    p_demo = sub.add_parser("demo", help="run the end-to-end demo (delegates to demo.sh)")
+    p_demo = sub.add_parser(
+        "demo",
+        help="run the end-to-end demo from a source checkout (requires demo.sh)",
+    )
     p_demo.set_defaults(func=cmd_demo, demo_args=[])
 
     return parser

--- a/atlas_core/cli.py
+++ b/atlas_core/cli.py
@@ -1,0 +1,272 @@
+"""Atlas umbrella CLI — one `atlas` command over the existing surfaces.
+
+Before this entry point, a `pip install`ed user could run nothing: every
+capability lived behind a `PYTHONPATH=. python -m ...` incantation, a raw
+Cypher query, or a curl call, even though the underlying functions were all
+implemented and tested. This module is the thin dispatch layer that turns
+those functions into subcommands. It reimplements no logic — each handler is
+a wrapper over a function that already ships.
+
+Subcommands:
+  atlas search <query>   — semantic retrieval via the vault-search daemon
+                           (atlas_core.retrieval.VaultSearchClient.search)
+  atlas queue            — list pending adjudication candidates
+                           (atlas_core.trust.QuarantineStore.list_pending)
+  atlas status           — most recent ingestion-daemon health row
+                           (atlas_core.daemon.health.HealthLogger.latest)
+  atlas ingest           — run one ingestion cycle
+                           (atlas_core.daemon.cycle.run_ingestion_cycle)
+  atlas demo             — run the end-to-end demo (delegates to demo.sh)
+
+Registered as the `atlas` console script in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROG = "atlas"
+
+
+# ─── Shared config helpers (match the env conventions of the sibling surfaces) ─
+
+
+def _data_dir() -> Path:
+    """Atlas data directory. Mirrors the daemon / adjudicate CLI default."""
+    return Path(os.path.expanduser(os.environ.get("ATLAS_DATA_DIR", "~/.atlas")))
+
+
+def _quarantine_db() -> Path:
+    """Candidate (quarantine) DB path.
+
+    Honors ATLAS_QUARANTINE_DB first (the var the MCP adapter reads), then
+    falls back to ATLAS_DATA_DIR/candidates.db (the daemon / adjudicate default).
+    """
+    override = os.environ.get("ATLAS_QUARANTINE_DB")
+    if override:
+        return Path(os.path.expanduser(override))
+    return _data_dir() / "candidates.db"
+
+
+def _print_json(obj: object) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True, default=str))
+
+
+# ─── search ───────────────────────────────────────────────────────────────────
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    """Delegate to VaultSearchClient.search — no retrieval logic lives here."""
+    from atlas_core.retrieval import DEFAULT_VAULT_SEARCH_URL, VaultSearchClient
+
+    base_url = args.url or DEFAULT_VAULT_SEARCH_URL
+    client = VaultSearchClient(base_url=base_url)
+    hits = client.search(args.query, k=args.k)
+
+    if args.json:
+        _print_json([
+            {"path": h.path, "score": h.score, "excerpt": h.excerpt}
+            for h in hits
+        ])
+        return 0
+
+    if not hits:
+        print(f"No hits for {args.query!r} (vault-search at {base_url}).")
+        return 0
+
+    print(f"{len(hits)} hit(s) for {args.query!r}:\n")
+    for h in hits:
+        print(f"  [{h.score:.3f}] {h.path}")
+        if h.excerpt:
+            print(f"          {h.excerpt.strip()[:160]}")
+    return 0
+
+
+# ─── queue ─────────────────────────────────────────────────────────────────────
+
+
+def cmd_queue(args: argparse.Namespace) -> int:
+    """Delegate to QuarantineStore.list_pending — the adjudication backlog."""
+    from atlas_core.trust import QuarantineStore
+
+    db_path = _quarantine_db()
+    if not db_path.exists():
+        print(f"error: {db_path} does not exist. Run `atlas ingest` first.", file=sys.stderr)
+        return 2
+
+    store = QuarantineStore(db_path)
+    rows = store.list_pending(lane=args.lane)[: args.limit]
+
+    if args.json:
+        _print_json(rows)
+        return 0
+
+    if not rows:
+        scope = f" on lane {args.lane!r}" if args.lane else ""
+        print(f"No pending candidates{scope}.")
+        return 0
+
+    print(f"{len(rows)} pending candidate(s):\n")
+    for r in rows:
+        conf = float(r.get("confidence", 0.0))
+        print(
+            f"  {r.get('candidate_id', '?')}  [{r.get('lane', '?')}]  "
+            f"conf={conf:.2f}  {r.get('subject_kref', '?')} "
+            f"{r.get('predicate', '?')} {r.get('object_value', '?')}"
+        )
+    return 0
+
+
+# ─── status ────────────────────────────────────────────────────────────────────
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Delegate to HealthLogger.latest — the last ingestion-cycle health row."""
+    from atlas_core.daemon.health import HealthLogger
+
+    row = HealthLogger("com.atlas.ingestion").latest()
+
+    if args.json:
+        _print_json(row.to_dict() if row is not None else None)
+        return 0
+
+    if row is None:
+        print("No ingestion cycles recorded yet. Run `atlas ingest`.")
+        return 0
+
+    state = "ok" if row.success else "FAILED"
+    print(f"ingestion daemon: {state}")
+    print(f"  started : {row.started_at}")
+    print(f"  finished: {row.finished_at}")
+    print(f"  elapsed : {row.elapsed_sec:.2f}s")
+    if row.summary:
+        print(f"  summary : {json.dumps(row.summary, sort_keys=True)}")
+    if row.error:
+        print(f"  error   : {row.error}")
+    return 0 if row.success else 1
+
+
+# ─── ingest ────────────────────────────────────────────────────────────────────
+
+
+def cmd_ingest(args: argparse.Namespace) -> int:
+    """Delegate to run_ingestion_cycle — one orchestration pass, returns its code."""
+    from atlas_core.daemon.cycle import run_ingestion_cycle
+
+    return run_ingestion_cycle()
+
+
+# ─── demo ──────────────────────────────────────────────────────────────────────
+
+
+def _find_demo_script() -> Path | None:
+    """Locate demo.sh.
+
+    demo.sh lives at the repo root and is intentionally excluded from the
+    packaged distribution (the sdist allowlist ships only atlas_core/** plus
+    metadata), so `atlas demo` resolves it from a source checkout. Resolution
+    order: ATLAS_DEMO_SCRIPT override, then the repo root above this package,
+    then the current working directory.
+    """
+    override = os.environ.get("ATLAS_DEMO_SCRIPT")
+    if override:
+        p = Path(os.path.expanduser(override))
+        return p if p.exists() else None
+
+    repo_root = Path(__file__).resolve().parent.parent
+    candidate = repo_root / "demo.sh"
+    if candidate.exists():
+        return candidate
+
+    cwd_candidate = Path.cwd() / "demo.sh"
+    if cwd_candidate.exists():
+        return cwd_candidate
+
+    return None
+
+
+def cmd_demo(args: argparse.Namespace) -> int:
+    """Delegate to demo.sh — the existing end-to-end demo path.
+
+    This is a minimal wrapper: it locates the script and shells out, passing
+    through any extra args (e.g. --quiet, --reset). demo.sh's own environment
+    requirements (a repo-root .venv, a reachable Neo4j) are unchanged and out
+    of scope for this entry point.
+    """
+    script = _find_demo_script()
+    if script is None:
+        print(
+            "error: demo.sh not found. It ships only in a source checkout, "
+            "not in the installed package. Run from the repo root, or set "
+            "ATLAS_DEMO_SCRIPT to its path.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        completed = subprocess.run([str(script), *args.demo_args])  # noqa: S603
+    except OSError as exc:
+        print(f"error: could not run {script}: {exc}", file=sys.stderr)
+        return 2
+    return completed.returncode
+
+
+# ─── parser ────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=PROG,
+        description="Atlas — local-first cognitive memory. One command over the graph.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+
+    p_search = sub.add_parser("search", help="semantic search over the vault")
+    p_search.add_argument("query", help="search query")
+    p_search.add_argument("-k", type=int, default=10, help="max hits (default: 10)")
+    p_search.add_argument("--url", default=None, help="vault-search base URL")
+    p_search.add_argument("--json", action="store_true", help="emit JSON")
+    p_search.set_defaults(func=cmd_search)
+
+    p_queue = sub.add_parser("queue", help="list pending adjudication candidates")
+    p_queue.add_argument("--lane", default=None, help="filter by lane")
+    p_queue.add_argument("--limit", type=int, default=50, help="max rows (default: 50)")
+    p_queue.add_argument("--json", action="store_true", help="emit JSON")
+    p_queue.set_defaults(func=cmd_queue)
+
+    p_status = sub.add_parser("status", help="show the last ingestion-cycle health")
+    p_status.add_argument("--json", action="store_true", help="emit JSON")
+    p_status.set_defaults(func=cmd_status)
+
+    p_ingest = sub.add_parser("ingest", help="run one ingestion cycle")
+    p_ingest.set_defaults(func=cmd_ingest)
+
+    # demo passes any extra flags (e.g. --quiet, --reset) straight through to
+    # demo.sh. Those are collected as unrecognized args in main() rather than
+    # declared here, so leading-dash flags aren't intercepted by this parser.
+    p_demo = sub.add_parser("demo", help="run the end-to-end demo (delegates to demo.sh)")
+    p_demo.set_defaults(func=cmd_demo, demo_args=[])
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args, extras = parser.parse_known_args(argv)
+    if getattr(args, "func", None) is None:
+        parser.print_help()
+        return 2
+    if args.command == "demo":
+        args.demo_args = extras
+    elif extras:
+        parser.error(f"unrecognized arguments: {' '.join(extras)}")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/atlas_core/ingestion/materializer.py
+++ b/atlas_core/ingestion/materializer.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from atlas_core.migrations.schema import ensure_schema
 from atlas_core.revision.uri import Kref
 
 if TYPE_CHECKING:
@@ -110,6 +111,10 @@ async def materialize_approved_candidates(
     quarantine: QuarantineStore,
 ) -> MaterializationReport:
     """Project every approved candidate; continue and report per-item failures."""
+    # Guarantee the belief-node uniqueness constraints exist before any MERGE,
+    # so concurrent materialization can never mint duplicate belief nodes.
+    await ensure_schema(driver)
+
     report = MaterializationReport()
     for candidate in quarantine.list_approved():
         report.attempted += 1

--- a/atlas_core/migrations/schema.py
+++ b/atlas_core/migrations/schema.py
@@ -1,0 +1,69 @@
+"""Neo4j graph schema — uniqueness constraints for belief-node identity.
+
+Atlas keys its property-graph nodes on stable URIs (``kref`` / ``root_kref``)
+and, for ingested beliefs, on ``candidate_id``.  Every production writer MERGEs
+on one of these keys expecting it to name *exactly one* node:
+
+    materializer  MERGE (:AtlasItem {kref})       / (:AtlasItem:Belief {candidate_id})
+    agm.revise    MERGE (:AtlasItem {root_kref})
+
+Neo4j does **not** enforce that expectation on its own: without a uniqueness
+constraint a MERGE's match-or-create step is not atomic across sessions, so two
+concurrent writers can each create a node for the same key.  Once a duplicate
+exists it corrupts every downstream write — a later ``MERGE (:AtlasItem {kref})
+SET ...`` matches *both* nodes and fans its update across all of them — and, at
+that point, the constraint can no longer be added.  The protection has to be in
+place *before* the first write.
+
+Scope note: only the three keys written via idempotent MERGE are constrained
+here.  ``:AtlasRevision {kref}`` is deliberately *not* constrained yet — AGM
+``revise`` / the resolver mint revisions with ``CREATE`` (``agm.py`` ~L158),
+which legitimately produces same-kref revisions on re-revision of identical
+content; adding that constraint requires first converting those writes to an
+idempotent MERGE (tracked as a separate identity-contract change).
+
+``ensure_schema`` installs the constraints idempotently (``IF NOT EXISTS``), so
+it is safe to call on every startup / batch run.  Each uniqueness constraint is
+backed by an automatically-maintained range index, which also gives labelled
+``kref`` lookups an index seek instead of a full-store scan.
+
+Uniqueness constraints are property-scoped: a node that lacks the constrained
+property is simply not covered, so the ``kref`` and ``root_kref`` constraints on
+``:AtlasItem`` coexist cleanly (a materialized subject has ``kref`` but no
+``root_kref``; an AGM root node has ``root_kref`` but no ``kref``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from neo4j import AsyncDriver
+
+# (constraint_name, node_label, property_key)
+BELIEF_CONSTRAINTS: tuple[tuple[str, str, str], ...] = (
+    ("atlas_item_kref_unique", "AtlasItem", "kref"),
+    ("atlas_item_root_kref_unique", "AtlasItem", "root_kref"),
+    ("belief_candidate_id_unique", "Belief", "candidate_id"),
+)
+
+
+def constraint_statements() -> list[str]:
+    """Return the idempotent ``CREATE CONSTRAINT`` statements for the schema."""
+    return [
+        f"CREATE CONSTRAINT {name} IF NOT EXISTS "
+        f"FOR (n:{label}) REQUIRE n.{prop} IS UNIQUE"
+        for name, label, prop in BELIEF_CONSTRAINTS
+    ]
+
+
+async def ensure_schema(driver: AsyncDriver) -> None:
+    """Install Atlas's belief-node uniqueness constraints if absent.
+
+    Idempotent and cheap: each statement uses ``IF NOT EXISTS`` so repeated
+    calls are no-ops.  Call it before any graph write path (ingestion /
+    materialization / revision) so duplicate belief nodes can never be minted.
+    """
+    async with driver.session() as session:
+        for statement in constraint_statements():
+            await session.run(statement)

--- a/benchmarks/business_mem_bench/adapters/atlas_system.py
+++ b/benchmarks/business_mem_bench/adapters/atlas_system.py
@@ -215,7 +215,7 @@ class AtlasSystem:
                                 "MERGE (s {kref: $obj}) "
                                 "WITH s "
                                 "MATCH (b:Belief {kref: $k}) "
-                                "MERGE (b)-[:DEPENDS_ON {strength: 0.85}]->(s)",
+                                "MERGE (b)-[:DEPENDS_ON {dependency_strength: 0.85}]->(s)",
                                 k=subject, obj=obj,
                             )
                 elif kind == "decision":

--- a/demo.sh
+++ b/demo.sh
@@ -148,8 +148,8 @@ async def main():
             "MERGE (c:AtlasItem:Decision {kref: $c}) SET c.deprecated = false, "
             "  c.confidence_score = 0.80, c.last_evidence_days = 0, "
             "  c.text = 'Market Origins to newcomers' "
-            "MERGE (b)-[:DEPENDS_ON {strength: 0.9}]->(a) "
-            "MERGE (c)-[:DEPENDS_ON {strength: 0.7}]->(b)",
+            "MERGE (b)-[:DEPENDS_ON {dependency_strength: 0.9}]->(a) "
+            "MERGE (c)-[:DEPENDS_ON {dependency_strength: 0.7}]->(b)",
             a=upstream, b=belief, c=decision,
         )
     print(f"  {GREEN}✓{RESET} 3 nodes + 2 Depends_On edges planted")

--- a/demo.sh
+++ b/demo.sh
@@ -115,10 +115,8 @@ async def main():
     from atlas_core.ripple.resolver import resolve_adjudication
     from atlas_core.ripple.adjudication import (
         AdjudicationRoute,
-        RoutingDecision,
         write_adjudication_entry,
     )
-    from atlas_core.ripple.reassess import ReassessmentProposal
     from atlas_core.trust import HashChainedLedger
 
     driver = AsyncGraphDatabase.driver(
@@ -144,6 +142,7 @@ async def main():
             "  a.confidence_score = 0.95, a.text = 'Origins is $89/mo' "
             "MERGE (b:AtlasItem:Belief {kref: $b}) SET b.deprecated = false, "
             "  b.confidence_score = 0.88, b.last_evidence_days = 0, "
+            "  b.stakes = 'high', "
             "  b.text = 'Origins is most accessible' "
             "MERGE (c:AtlasItem:Decision {kref: $c}) SET c.deprecated = false, "
             "  c.confidence_score = 0.80, c.last_evidence_days = 0, "
@@ -209,13 +208,12 @@ async def main():
         ledger_path = Path(tempfile.mkdtemp(prefix="atlas_demo_ledger_")) / "ledger.db"
         ledger = HashChainedLedger(ledger_path)
 
-        decision_obj = RoutingDecision(
-            proposal_kref=proposal.target_kref,
-            route=AdjudicationRoute.STRATEGIC_REVIEW,
-            rationale="Demo — review the price-cascade outcome",
-            contradictions_count=len(cascade.contradictions),
-            confidence_delta=proposal.new_confidence - proposal.old_confidence,
-        )
+        decision_obj = cascade.routing[0]
+        if decision_obj.route == AdjudicationRoute.AUTO_APPLY:
+            print(f"  {YELLOW}⚠ first proposal unexpectedly routed AUTO_APPLY; "
+                  f"refusing to narrate a manual resolution as automatic{RESET}")
+            await driver.close()
+            sys.exit(3)
         path = await write_adjudication_entry(
             proposal=proposal,
             decision=decision_obj,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       NEO4J_AUTH: neo4j/atlasdev
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: 'apoc.*'
-      NEO4J_dbms_memory_heap_max__size: '2G'
-      NEO4J_dbms_memory_pagecache_size: '1G'
+      NEO4J_server_memory_heap_max__size: '2G'
+      NEO4J_server_memory_pagecache_size: '1G'
     volumes:
       - ./neo4j-data:/data
       - ./neo4j-logs:/logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,13 @@ adapters = [
     # Reserved for future version-pinned native wrapper packages.
 ]
 
+[project.scripts]
+# The `atlas` umbrella CLI — a thin dispatch layer over the existing
+# search / queue / status / ingest / demo surfaces. Without this, a
+# pip-installed user has no bare command and must know the underlying
+# `python -m ...` incantations.
+atlas = "atlas_core.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/RichSchefren/atlas"
 Documentation = "https://github.com/RichSchefren/atlas/tree/main/docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "neo4j>=5.26.0",
     "pydantic>=2.0,<3",
     "python-ulid>=2.0",
-    "tenacity>=8.0",
     "fastapi>=0.110",
     "uvicorn>=0.27",
     "watchdog>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ dev = [
     "hypothesis>=6.100",
     "ruff>=0.4",
     "mypy>=1.10",
+    # The sdist-allowlist tests build a real sdist; without this they skip.
+    "build>=1.0",
     "testcontainers[neo4j]>=4.0",
     # Tests cover the LLM paths via mocked clients; no need to ship
     # the real anthropic SDK for the test suite, but include it so
@@ -118,6 +120,20 @@ Repository = "https://github.com/RichSchefren/atlas"
 
 [tool.hatch.build.targets.wheel]
 packages = ["atlas_core"]
+
+# Source distribution is an explicit allowlist: a runtime install only
+# needs the importable package plus the metadata files that build/install
+# and license the project. Everything else in the repo tree (dev tooling,
+# docs, site assets, benchmarks, examples, ops material, CI config, ...)
+# is excluded by construction rather than by an ever-growing deny list.
+[tool.hatch.build.targets.sdist]
+include = [
+    "atlas_core/**",
+    "/README.md",
+    "/LICENSE",
+    "/NOTICE",
+    "/pyproject.toml",
+]
 
 [tool.ruff]
 line-length = 120

--- a/scripts/demo_loop.py
+++ b/scripts/demo_loop.py
@@ -168,7 +168,7 @@ async def main() -> None:
         )
         await session.run(
             "MATCH (b {kref: $b}), (p {kref: $p}) "
-            "MERGE (b)-[:DEPENDS_ON {strength: 0.9, dependency_strength: 0.9}]->(p)",
+            "MERGE (b)-[:DEPENDS_ON {dependency_strength: 0.9}]->(p)",
             b="kref://demo/Beliefs/most_accessible.belief",
             p="kref://demo/Programs/origins.belief",
         )

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,111 @@
+"""End-to-end tests for the `atlas` CLI against the REAL shipped surfaces.
+
+Unlike tests/unit/test_cli.py (which mocks the delegated functions to isolate
+parsing/dispatch), these drive the CLI against real QuarantineStore and
+HealthLogger instances backed by real files, plus a real subprocess for the
+demo wrapper. They prove the thin dispatch layer actually reaches the shipped
+functions. No Neo4j and no vault-search daemon are required.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+
+from atlas_core import cli
+from atlas_core.daemon.health import HealthLogger, HealthRow
+from atlas_core.trust.quarantine import QuarantineStore
+
+
+def _seed_pending(quarantine: QuarantineStore, *, candidate_id: str, lane: str) -> None:
+    """Insert one PENDING candidate directly (matches list_pending's status filter)."""
+    payload = {
+        "candidate_id": candidate_id,
+        "fingerprint": f"fp_{candidate_id}",
+        "status": "pending",
+        "risk_level": "low",
+        "policy_version": "v1",
+        "trust_score": 0.6,
+        "lane": lane,
+        "assertion_type": "factual_assertion",
+        "subject_kref": "kref://Atlas/Test/widget",
+        "predicate": "color",
+        "object_value": "blue",
+        "scope": "global",
+        "evidence_refs_json": json.dumps([{"source": "test", "source_family": "test"}]),
+        "evidence_stats_json": json.dumps({"n_sources": 1}),
+        "confidence": 0.62,
+        "policy_trace_json": json.dumps({"recommendation": "review"}),
+    }
+    cols = ", ".join(payload.keys())
+    placeholders = ", ".join("?" * len(payload))
+    now = "2026-07-16T00:00:00Z"
+    with quarantine._connection() as conn:
+        conn.execute(
+            f"INSERT INTO candidates ({cols}, created_at, updated_at) "
+            f"VALUES ({placeholders}, ?, ?)",
+            (*payload.values(), now, now),
+        )
+
+
+def test_queue_lists_real_pending_candidates(monkeypatch, tmp_path, capsys):
+    db = tmp_path / "candidates.db"
+    store = QuarantineStore(db_path=db)
+    _seed_pending(store, candidate_id="alpha", lane="atlas_vault")
+    _seed_pending(store, candidate_id="beta", lane="atlas_meeting")
+
+    monkeypatch.setenv("ATLAS_QUARANTINE_DB", str(db))
+
+    rc = cli.main(["queue", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    ids = {r["candidate_id"] for r in payload}
+    assert ids == {"alpha", "beta"}
+
+    # Lane filter flows through to the real query.
+    rc = cli.main(["queue", "--lane", "atlas_vault", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert [r["candidate_id"] for r in payload] == ["alpha"]
+
+
+def test_status_reads_real_health_row(monkeypatch, tmp_path, capsys):
+    # HealthLogger defaults to ~/.atlas/health; point HOME at a temp dir so the
+    # CLI's own HealthLogger("com.atlas.ingestion") resolves to our seeded file.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    logger = HealthLogger("com.atlas.ingestion")
+    logger.append(HealthRow(
+        daemon="com.atlas.ingestion",
+        started_at="2026-07-16T00:00:00Z",
+        finished_at="2026-07-16T00:00:05Z",
+        success=True,
+        elapsed_sec=5.0,
+        summary={"ingested": 4},
+    ))
+
+    rc = cli.main(["status", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["success"] is True
+    assert payload["summary"] == {"ingested": 4}
+
+
+def test_demo_runs_a_real_script(monkeypatch, tmp_path):
+    script = tmp_path / "demo.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("ATLAS_DEMO_SCRIPT", str(script))
+
+    assert cli.main(["demo"]) == 0
+
+
+def test_demo_propagates_real_nonzero_exit(monkeypatch, tmp_path):
+    script = tmp_path / "demo.sh"
+    script.write_text("#!/bin/sh\nexit 4\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("ATLAS_DEMO_SCRIPT", str(script))
+
+    assert cli.main(["demo"]) == 4

--- a/tests/integration/test_ripple_engine.py
+++ b/tests/integration/test_ripple_engine.py
@@ -100,7 +100,7 @@ class TestEngineOneHop:
                 "  a.confidence_score = 0.9 "
                 "MERGE (b:AtlasItem {kref: $b}) SET b.deprecated = false, "
                 "  b.confidence_score = 0.85, b.last_evidence_days = 0 "
-                "MERGE (b)-[:DEPENDS_ON {strength: 0.8}]->(a)",
+                "MERGE (b)-[:DEPENDS_ON {dependency_strength: 0.8}]->(a)",
                 a=upstream, b=downstream,
             )
 
@@ -128,7 +128,7 @@ class TestEngineOneHop:
                 "  a.confidence_score = 0.9 "
                 "MERGE (b:AtlasItem {kref: $b}) SET b.deprecated = false, "
                 "  b.confidence_score = 0.8, b.last_evidence_days = 0 "
-                "MERGE (b)-[:DEPENDS_ON {strength: 0.7}]->(a)",
+                "MERGE (b)-[:DEPENDS_ON {dependency_strength: 0.7}]->(a)",
                 a=upstream, b=downstream,
             )
 
@@ -163,8 +163,8 @@ class TestEngineMultiHop:
                 "  m.confidence_score = 0.85, m.last_evidence_days = 0 "
                 "MERGE (l:AtlasItem {kref: $l}) SET l.deprecated = false, "
                 "  l.confidence_score = 0.80, l.last_evidence_days = 0 "
-                "MERGE (m)-[:DEPENDS_ON {strength: 0.8}]->(r) "
-                "MERGE (l)-[:DEPENDS_ON {strength: 0.7}]->(m)",
+                "MERGE (m)-[:DEPENDS_ON {dependency_strength: 0.8}]->(r) "
+                "MERGE (l)-[:DEPENDS_ON {dependency_strength: 0.7}]->(m)",
                 r=upstream, m=mid, l=leaf,
             )
 

--- a/tests/integration/test_schema_constraints.py
+++ b/tests/integration/test_schema_constraints.py
@@ -1,0 +1,132 @@
+"""Integration tests for Atlas's Neo4j belief-node uniqueness constraints.
+
+Audit finding (atlas #8): "No Neo4j indexes or constraints anywhere ... an
+unconstrained MERGE key risks duplicate-node corruption under concurrent
+writers."  These tests pin the fix: `ensure_schema` installs uniqueness
+constraints so a duplicate belief kref can never be minted.
+
+Requires a live Neo4j (the same instance the rest of tests/integration uses).
+"""
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CONSTRAINT_NAMES = {
+    "atlas_item_kref_unique",
+    "atlas_item_root_kref_unique",
+    "belief_candidate_id_unique",
+}
+
+
+@pytest.fixture(scope="module")
+def neo4j_uri() -> str:
+    return os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+
+
+@pytest.fixture(scope="module")
+def neo4j_auth() -> tuple[str, str]:
+    return (
+        os.environ.get("NEO4J_USER", "neo4j"),
+        os.environ.get("NEO4J_PASSWORD", "atlasdev"),
+    )
+
+
+@pytest.fixture
+async def driver(neo4j_uri, neo4j_auth):
+    pytest.importorskip("neo4j")
+    from neo4j import AsyncGraphDatabase
+
+    user, password = neo4j_auth
+    drv = AsyncGraphDatabase.driver(neo4j_uri, auth=(user, password))
+    try:
+        await drv.verify_connectivity()
+        yield drv
+    finally:
+        await drv.close()
+
+
+@pytest.fixture
+def ns() -> str:
+    return f"kref://SchemaConstraintTest_{uuid.uuid4().hex[:8]}/Beliefs/x.belief"
+
+
+async def _delete_ns(driver, ns: str) -> None:
+    async with driver.session() as session:
+        await session.run("MATCH (n {kref: $k}) DETACH DELETE n", k=ns)
+
+
+async def _count(driver, ns: str) -> int:
+    async with driver.session() as session:
+        result = await session.run("MATCH (n {kref: $k}) RETURN count(n) AS n", k=ns)
+        record = await result.single()
+    return int(record["n"])
+
+
+async def test_ensure_schema_installs_belief_constraints(driver):
+    """ensure_schema creates every named belief-node uniqueness constraint."""
+    from atlas_core.migrations.schema import ensure_schema
+
+    await ensure_schema(driver)
+
+    async with driver.session() as session:
+        result = await session.run("SHOW CONSTRAINTS YIELD name RETURN name")
+        names = {record["name"] async for record in result}
+
+    assert CONSTRAINT_NAMES.issubset(names), (
+        f"missing constraints: {CONSTRAINT_NAMES - names}"
+    )
+
+
+async def test_ensure_schema_is_idempotent(driver):
+    """Calling ensure_schema repeatedly is a no-op, never an error."""
+    from atlas_core.migrations.schema import ensure_schema
+
+    await ensure_schema(driver)
+    await ensure_schema(driver)  # second call must not raise
+
+
+async def test_unconstrained_label_permits_duplicate_kref(driver, ns):
+    """Control: a label with no uniqueness constraint permits duplicate krefs.
+
+    This pins the pre-fix behavior (Neo4j does not enforce key uniqueness on its
+    own) using a throwaway label, so it never perturbs the real constraints that
+    the rest of the suite relies on.
+    """
+    async with driver.session() as session:
+        await session.run("MATCH (n:ReproUnconstrained {kref: $k}) DETACH DELETE n", k=ns)
+    try:
+        async with driver.session() as session:
+            await session.run("CREATE (:ReproUnconstrained {kref: $k})", k=ns)
+            await session.run("CREATE (:ReproUnconstrained {kref: $k})", k=ns)
+            result = await session.run(
+                "MATCH (n:ReproUnconstrained {kref: $k}) RETURN count(n) AS n", k=ns
+            )
+            record = await result.single()
+        assert int(record["n"]) == 2, "expected duplicates on an unconstrained label"
+    finally:
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (n:ReproUnconstrained {kref: $k}) DETACH DELETE n", k=ns
+            )
+
+
+async def test_duplicate_kref_rejected_after_ensure_schema(driver, ns):
+    """After ensure_schema, a second node with the same AtlasItem kref is rejected."""
+    from neo4j.exceptions import ConstraintError
+
+    from atlas_core.migrations.schema import ensure_schema
+
+    await ensure_schema(driver)
+    await _delete_ns(driver, ns)
+    try:
+        async with driver.session() as session:
+            await session.run("CREATE (:AtlasItem:Belief {kref: $k})", k=ns)
+            with pytest.raises(ConstraintError):
+                await session.run("CREATE (:AtlasItem:Belief {kref: $k})", k=ns)
+        assert await _count(driver, ns) == 1, "duplicate must not have been created"
+    finally:
+        await _delete_ns(driver, ns)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,310 @@
+"""Unit tests for the `atlas` umbrella CLI.
+
+The CLI is a thin dispatch layer: every subcommand forwards to a function
+that already ships and is tested elsewhere. These tests exercise argument
+parsing and dispatch with the delegated functions mocked, so they need no
+Neo4j, no vault-search daemon, and no filesystem state.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atlas_core import cli
+
+# ─── parser wiring ─────────────────────────────────────────────────────────────
+
+
+def test_no_command_prints_help_and_returns_2(capsys):
+    rc = cli.main([])
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "usage" in out.lower()
+    # Every subcommand should be advertised in the top-level help.
+    for name in ("search", "queue", "status", "ingest", "demo"):
+        assert name in out
+
+
+@pytest.mark.parametrize("argv", [["--help"], ["search", "--help"], ["queue", "--help"],
+                                  ["status", "--help"], ["ingest", "--help"], ["demo", "--help"]])
+def test_help_exits_zero(argv):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(argv)
+    assert exc.value.code == 0
+
+
+def test_each_subcommand_dispatches_to_its_handler():
+    parser = cli.build_parser()
+    expected = {
+        "search": cli.cmd_search,
+        "queue": cli.cmd_queue,
+        "status": cli.cmd_status,
+        "ingest": cli.cmd_ingest,
+        "demo": cli.cmd_demo,
+    }
+    for name, handler in expected.items():
+        args = parser.parse_args([name] if name != "search" else [name, "q"])
+        assert args.func is handler
+
+
+# ─── search ────────────────────────────────────────────────────────────────────
+
+
+class _FakeHit:
+    def __init__(self, path, score, excerpt):
+        self.path = path
+        self.score = score
+        self.excerpt = excerpt
+
+
+def test_search_delegates_to_vault_search_client(monkeypatch, capsys):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, *, base_url):
+            captured["base_url"] = base_url
+
+        def search(self, query, *, k):
+            captured["query"] = query
+            captured["k"] = k
+            return [_FakeHit("notes/a.md", 0.91, "an excerpt")]
+
+    monkeypatch.setattr("atlas_core.retrieval.VaultSearchClient", FakeClient)
+
+    rc = cli.main(["search", "quarterly plan", "-k", "3", "--url", "http://x:9999"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert captured == {"base_url": "http://x:9999", "query": "quarterly plan", "k": 3}
+    assert "notes/a.md" in out
+    assert "0.910" in out
+
+
+def test_search_json_output(monkeypatch, capsys):
+    class FakeClient:
+        def __init__(self, *, base_url):
+            pass
+
+        def search(self, query, *, k):
+            return [_FakeHit("p.md", 0.5, "ex")]
+
+    monkeypatch.setattr("atlas_core.retrieval.VaultSearchClient", FakeClient)
+
+    rc = cli.main(["search", "x", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload == [{"path": "p.md", "score": 0.5, "excerpt": "ex"}]
+
+
+def test_search_empty_results(monkeypatch, capsys):
+    class FakeClient:
+        def __init__(self, *, base_url):
+            pass
+
+        def search(self, query, *, k):
+            return []
+
+    monkeypatch.setattr("atlas_core.retrieval.VaultSearchClient", FakeClient)
+    rc = cli.main(["search", "nothing"])
+    assert rc == 0
+    assert "No hits" in capsys.readouterr().out
+
+
+# ─── queue ─────────────────────────────────────────────────────────────────────
+
+
+def test_queue_delegates_to_list_pending(monkeypatch, tmp_path, capsys):
+    db = tmp_path / "candidates.db"
+    db.write_text("")  # existence is all the handler checks
+    monkeypatch.setenv("ATLAS_QUARANTINE_DB", str(db))
+
+    captured = {}
+
+    class FakeStore:
+        def __init__(self, path):
+            captured["path"] = path
+
+        def list_pending(self, *, lane):
+            captured["lane"] = lane
+            return [
+                {"candidate_id": "c1", "lane": "atlas_vault", "confidence": 0.7,
+                 "subject_kref": "S", "predicate": "P", "object_value": "O"},
+            ]
+
+    monkeypatch.setattr("atlas_core.trust.QuarantineStore", FakeStore)
+
+    rc = cli.main(["queue", "--lane", "atlas_vault", "--limit", "10"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert captured["lane"] == "atlas_vault"
+    assert str(captured["path"]) == str(db)
+    assert "c1" in out
+    assert "conf=0.70" in out
+
+
+def test_queue_limit_truncates(monkeypatch, tmp_path, capsys):
+    db = tmp_path / "candidates.db"
+    db.write_text("")
+    monkeypatch.setenv("ATLAS_QUARANTINE_DB", str(db))
+
+    class FakeStore:
+        def __init__(self, path):
+            pass
+
+        def list_pending(self, *, lane):
+            return [{"candidate_id": f"c{i}", "lane": "l", "confidence": 0.5,
+                     "subject_kref": "s", "predicate": "p", "object_value": "o"}
+                    for i in range(100)]
+
+    monkeypatch.setattr("atlas_core.trust.QuarantineStore", FakeStore)
+    rc = cli.main(["queue", "--limit", "2", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert len(payload) == 2
+
+
+def test_queue_missing_db_returns_2(monkeypatch, tmp_path, capsys):
+    missing = tmp_path / "nope.db"
+    monkeypatch.setenv("ATLAS_QUARANTINE_DB", str(missing))
+    rc = cli.main(["queue"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "does not exist" in err
+
+
+# ─── status ────────────────────────────────────────────────────────────────────
+
+
+class _FakeRow:
+    def __init__(self, success):
+        self.success = success
+        self.started_at = "2026-07-16T00:00:00Z"
+        self.finished_at = "2026-07-16T00:00:06Z"
+        self.elapsed_sec = 6.0
+        self.summary = {"ingested": 3}
+        self.error = None if success else "boom"
+
+    def to_dict(self):
+        return {"success": self.success, "started_at": self.started_at}
+
+
+def test_status_ok_row(monkeypatch, capsys):
+    class FakeLogger:
+        def __init__(self, name):
+            pass
+
+        def latest(self):
+            return _FakeRow(success=True)
+
+    monkeypatch.setattr("atlas_core.daemon.health.HealthLogger", FakeLogger)
+    rc = cli.main(["status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ok" in out
+    assert "ingested" in out
+
+
+def test_status_failed_row_returns_1(monkeypatch, capsys):
+    class FakeLogger:
+        def __init__(self, name):
+            pass
+
+        def latest(self):
+            return _FakeRow(success=False)
+
+    monkeypatch.setattr("atlas_core.daemon.health.HealthLogger", FakeLogger)
+    rc = cli.main(["status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED" in out
+    assert "boom" in out
+
+
+def test_status_no_history(monkeypatch, capsys):
+    class FakeLogger:
+        def __init__(self, name):
+            pass
+
+        def latest(self):
+            return None
+
+    monkeypatch.setattr("atlas_core.daemon.health.HealthLogger", FakeLogger)
+    rc = cli.main(["status", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) is None
+
+
+# ─── ingest ────────────────────────────────────────────────────────────────────
+
+
+def test_ingest_delegates_and_returns_code(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_cycle():
+        calls["n"] += 1
+        return 7
+
+    monkeypatch.setattr("atlas_core.daemon.cycle.run_ingestion_cycle", fake_cycle)
+    rc = cli.main(["ingest"])
+    assert rc == 7
+    assert calls["n"] == 1
+
+
+# ─── demo ──────────────────────────────────────────────────────────────────────
+
+
+def test_demo_delegates_to_demo_sh(monkeypatch, tmp_path):
+    fake_script = tmp_path / "demo.sh"
+    fake_script.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cli, "_find_demo_script", lambda: fake_script)
+
+    captured = {}
+
+    class FakeCompleted:
+        returncode = 0
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return FakeCompleted()
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    rc = cli.main(["demo", "--quiet", "--reset"])
+    assert rc == 0
+    assert captured["cmd"] == [str(fake_script), "--quiet", "--reset"]
+
+
+def test_demo_missing_script_returns_2(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_find_demo_script", lambda: None)
+    rc = cli.main(["demo"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "demo.sh not found" in err
+
+
+def test_demo_propagates_returncode(monkeypatch, tmp_path):
+    fake_script = tmp_path / "demo.sh"
+    fake_script.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cli, "_find_demo_script", lambda: fake_script)
+
+    class FakeCompleted:
+        returncode = 3
+
+    monkeypatch.setattr(cli.subprocess, "run", lambda cmd, *a, **k: FakeCompleted())
+    assert cli.main(["demo"]) == 3
+
+
+def test_find_demo_script_env_override(monkeypatch, tmp_path):
+    script = tmp_path / "custom-demo.sh"
+    script.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("ATLAS_DEMO_SCRIPT", str(script))
+    assert cli._find_demo_script() == script
+
+
+def test_find_demo_script_repo_root(monkeypatch):
+    # The real demo.sh sits at the repo root above the package; no override.
+    monkeypatch.delenv("ATLAS_DEMO_SCRIPT", raising=False)
+    found = cli._find_demo_script()
+    assert found is not None
+    assert found.name == "demo.sh"

--- a/tests/unit/test_depends_on_edge_property.py
+++ b/tests/unit/test_depends_on_edge_property.py
@@ -1,0 +1,69 @@
+"""Guard: DEPENDS_ON writers must use the property the engine reads.
+
+RippleEngine reads exactly one edge property to attenuate propagation:
+
+    coalesce(r.dependency_strength, 1.0)     # ripple/reassess.py
+
+A writer that spells it `strength` does not error — the value is silently
+discarded and the edge propagates at the hard-dependency default of 1.0.
+That is how demo.sh's showcase cascade ran unattenuated: the demo wrote
+`{strength: 0.9}` while the engine read `dependency_strength`.
+
+These tests scan every Cypher-writing source file for DEPENDS_ON edge maps
+and fail if one carries a bare `strength` key. `strength` remains the
+correct property name for SUPPORTS edges (lineage/extractor.py), so the
+scan is scoped to DEPENDS_ON only.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SCAN_SUFFIXES = {".py", ".sh", ".cypher"}
+_SKIP_PARTS = {".git", ".venv", "node_modules", "neo4j-data", "neo4j-logs"}
+
+_EDGE_MAP = re.compile(r"DEPENDS_ON\s*\{([^}]*)\}")
+_MAP_KEY = re.compile(r"(\w+)\s*:")
+
+
+def _sources() -> list[Path]:
+    return [
+        path
+        for path in _REPO_ROOT.rglob("*")
+        if path.suffix in _SCAN_SUFFIXES
+        and path.is_file()
+        and not _SKIP_PARTS.intersection(path.parts)
+    ]
+
+
+def _depends_on_edge_maps() -> list[tuple[Path, str]]:
+    found = []
+    for path in _sources():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for match in _EDGE_MAP.finditer(text):
+            found.append((path, match.group(1)))
+    return found
+
+
+def test_scan_actually_sees_the_known_writers() -> None:
+    """If globbing breaks, the property test below would pass vacuously."""
+    writer_files = {path.name for path, _ in _depends_on_edge_maps()}
+    assert "demo.sh" in writer_files
+    assert "test_ripple_engine.py" in writer_files
+
+
+def test_depends_on_writers_use_the_property_the_engine_reads() -> None:
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT)}: DEPENDS_ON {{{body.strip()}}}"
+        for path, body in _depends_on_edge_maps()
+        for key in _MAP_KEY.findall(body)
+        if key == "strength"
+    ]
+    assert not offenders, (
+        "DEPENDS_ON edges written with a bare `strength` key are silently "
+        "read as dependency_strength=1.0 (no attenuation). Use "
+        "`dependency_strength`:\n" + "\n".join(offenders)
+    )

--- a/tests/unit/test_sdist_allowlist.py
+++ b/tests/unit/test_sdist_allowlist.py
@@ -1,0 +1,104 @@
+"""The source distribution is an explicit allowlist.
+
+A runtime install from source only needs the importable package plus the
+metadata files that build, install, and license the project. The repo tree
+also carries docs, site media, benchmarks, examples, CI config, and dev/ops
+tooling — none of which belong in a distribution. Rather than maintain an
+ever-growing deny list, ``pyproject.toml`` pins ``[tool.hatch.build.targets.sdist]``
+to an allowlist so everything else is excluded by construction.
+
+This test builds the sdist and asserts its members are exactly that allowlist,
+so a future directory added at the repo root cannot silently start shipping.
+
+Spec: pyproject.toml § [tool.hatch.build.targets.sdist]
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_HAS_BUILD = importlib.util.find_spec("build") is not None
+
+# Root-level metadata files a runtime source install legitimately carries,
+# plus the backend-generated / force-included sdist artifacts (not repo
+# content): PKG-INFO is written by the build backend, and hatchling always
+# ships the VCS ignore file in an sdist.
+ALLOWED_ROOT_FILES = frozenset(
+    {
+        "README.md",
+        "LICENSE",
+        "NOTICE",
+        "pyproject.toml",
+        "PKG-INFO",
+        ".gitignore",
+    }
+)
+
+# The only directory a distribution needs: the importable package itself.
+ALLOWED_TOP_DIRS = frozenset({"atlas_core"})
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _build_sdist(outdir: Path) -> Path:
+    subprocess.run(
+        [sys.executable, "-m", "build", "--sdist", "--outdir", str(outdir)],
+        cwd=str(PROJECT_ROOT),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tarballs = sorted(outdir.glob("*.tar.gz"))
+    assert tarballs, "build produced no sdist tarball"
+    return tarballs[-1]
+
+
+def _extraneous_members(tarball: Path) -> list[str]:
+    offenders: list[str] = []
+    with tarfile.open(tarball, "r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile():
+                continue
+            # Strip the "<name>-<version>/" prefix sdists wrap everything in.
+            parts = Path(member.name).parts
+            rel = Path(*parts[1:]) if len(parts) > 1 else Path(member.name)
+            if rel.parts[0] in ALLOWED_TOP_DIRS:
+                continue
+            if len(rel.parts) == 1 and rel.parts[0] in ALLOWED_ROOT_FILES:
+                continue
+            offenders.append(str(rel))
+    return sorted(offenders)
+
+
+@pytest.mark.skipif(not _HAS_BUILD, reason="the `build` frontend is not installed")
+def test_sdist_contains_only_the_allowlist() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tarball = _build_sdist(Path(td))
+        offenders = _extraneous_members(tarball)
+    assert offenders == [], (
+        f"sdist ships {len(offenders)} file(s) outside the allowlist "
+        f"(first few: {offenders[:5]}); tighten "
+        "[tool.hatch.build.targets.sdist] in pyproject.toml"
+    )
+
+
+@pytest.mark.skipif(not _HAS_BUILD, reason="the `build` frontend is not installed")
+def test_sdist_still_ships_the_package() -> None:
+    """The allowlist must not starve the actual install."""
+    with tempfile.TemporaryDirectory() as td:
+        tarball = _build_sdist(Path(td))
+        with tarfile.open(tarball, "r:gz") as tf:
+            members = [m.name for m in tf.getmembers() if m.isfile()]
+    package_files = [m for m in members if "/atlas_core/" in f"/{m}"]
+    py_modules = [m for m in package_files if m.endswith(".py")]
+    assert len(py_modules) > 50, "sdist is missing package source modules"
+    # Package data (non-.py resources under the package) must survive too.
+    data_files = [m for m in package_files if not m.endswith(".py")]
+    assert data_files, "sdist dropped the package's non-.py data files"


### PR DESCRIPTION
## What this PR does

Selectively ports the valuable, non-overlapping work from Tony Flo's Atlas fork onto the current upstream master while preserving the completed Hermes, OpenClaw, and GBrain packages.

Included:

- standardize DEPENDS_ON writers on dependency_strength;
- install Neo4j uniqueness constraints before candidate materialization;
- add an explicit source-distribution allowlist and real package-content tests;
- remove Atlas's unused direct tenacity dependency and empty adjudication package;
- run demo.sh end to end against Neo4j in CI;
- update Docker Compose to Neo4j 5 server.memory keys;
- add the atlas umbrella CLI for search, queue, status, ingest, and the source-checkout demo;
- run every branch-protection-required host/service workflow on every PR instead of leaving required checks absent behind path filters;
- preserve Tony's authorship on every directly ported commit.

The demo proof was strengthened during integration. It now uses the actual Ripple routing decision, requires one real STRATEGIC_REVIEW result, resolves that proposal, and refuses to narrate an AUTO_APPLY proposal as a manual strategic resolution.

## Deliberately excluded

Tony's raw-Graphiti Ripple hook, HTTP-auth implementation, and adjudication projection were not imported. Draft PR #34 owns those trust-boundary changes and uses the stronger approved-candidate materialization design.

This is not a wholesale merge of the fork. Tony's branch predates the three-host integration and is two upstream commits behind.

## Verification

- 443 unit/service tests passed
- 208 live-Neo4j integration tests passed
- 31 focused CLI/package tests passed
- real seven-stage demo.sh passed with strategic routing, resolution, and intact ledger
- fresh wheel and sdist built successfully
- fresh wheel install imported atlas_core 0.1.0a1 and exposed the atlas command
- wheel: 201 KB; sdist: 161 KB
- ruff, compileall, git diff --check, and Docker Compose validation passed

GitHub's protected Python, Windows, service, Hermes, OpenClaw, and GBrain checks remain the merge gate.
